### PR TITLE
카카오맵 객체가 쌓이지 않고 현재 위치 이동, zoom in/out 되도록 변경

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   images: {
     remotePatterns: [
       {

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'maps.googleapis.com',
+        pathname: '/_next/image/**',
       },
     ],
   },

--- a/next.config.js
+++ b/next.config.js
@@ -7,11 +7,6 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'maps.googleapis.com',
       },
-      {
-        protocol: 'https',
-        hostname: 'team-kkini-mukvengers-fe.vercel.app',
-        pathname: '/_next/image/**',
-      },
     ],
   },
   compiler: {

--- a/src/components/common/KakaoMap/index.tsx
+++ b/src/components/common/KakaoMap/index.tsx
@@ -37,36 +37,36 @@ const KakaoMap = () => {
 
   // 카카오맵을 생성하고 생성된 맵 객체를 state로 저장.
   useEffect(() => {
+    kakao.maps.load(() => {
+      if (kakaoMap || !kakaoMapRef.current) return;
+
+      const {
+        center: { lat, lng },
+        level,
+      } = kakaoMapOptions;
+      const options: kakao.maps.MapOptions = {
+        center: new kakao.maps.LatLng(lat, lng),
+        level: level,
+      };
+      const createdKakaoMap = new kakao.maps.Map(kakaoMapRef.current, options);
+      setKakaoMap(createdKakaoMap);
+    });
+  }, [kakaoMap, kakaoMapOptions, setKakaoMap]);
+
+  // 마커 생성
+  useEffect(() => {
+    if (!kakaoMap || !randomRestaurant.marker) return;
+
     const handleClickKakaoMapMarker = () => {
       setRandomRestaurantOpen(true);
     };
 
-    kakao.maps.load(() => {
-      if (kakaoMap) return;
-
-      if (kakaoMapRef.current) {
-        const {
-          center: { lat, lng },
-          level,
-        } = kakaoMapOptions;
-        const options: kakao.maps.MapOptions = {
-          center: new kakao.maps.LatLng(lat, lng),
-          level: level,
-        };
-        const createdKakaoMap = new kakao.maps.Map(kakaoMapRef.current, options);
-
-        if (randomRestaurant.marker) {
-          randomRestaurant.marker.setMap(createdKakaoMap);
-          kakaoMapAddEventListener(
-            randomRestaurant.marker,
-            KAKAO_MARKER_EVENT_TYPE.CLICK,
-            handleClickKakaoMapMarker
-          );
-        }
-
-        setKakaoMap(createdKakaoMap);
-      }
-    });
+    randomRestaurant.marker.setMap(kakaoMap);
+    kakaoMapAddEventListener(
+      randomRestaurant.marker,
+      KAKAO_MARKER_EVENT_TYPE.CLICK,
+      handleClickKakaoMapMarker
+    );
 
     return () => {
       if (randomRestaurant.marker) {
@@ -75,9 +75,10 @@ const KakaoMap = () => {
           KAKAO_MARKER_EVENT_TYPE.CLICK,
           handleClickKakaoMapMarker
         );
+        randomRestaurant.marker.setMap(null);
       }
     };
-  }, []);
+  }, [kakaoMap, kakaoMapAddEventListener, randomRestaurant]);
 
   return (
     <Box position='relative' width='100%' height='100%'>

--- a/src/components/common/KakaoMap/index.tsx
+++ b/src/components/common/KakaoMap/index.tsx
@@ -20,7 +20,7 @@ const KAKAO_MARKER_EVENT_TYPE = {
 
 const KakaoMap = () => {
   const kakaoMapRef = useRef<HTMLDivElement>(null);
-  const { setKakaoMap, kakaoMapAddEventListener } = useKakaoMapContext();
+  const { kakaoMap, setKakaoMap, kakaoMapAddEventListener } = useKakaoMapContext();
   const kakaoMapOptions = useRecoilValue(kakaoMapOptionsState);
   const { moveToCurrentLocation, moveToCurrentLocationIsLoading, zoomIn, zoomOut } =
     useOperateKakaoMap();
@@ -42,6 +42,8 @@ const KakaoMap = () => {
     };
 
     kakao.maps.load(() => {
+      if (kakaoMap) return;
+
       if (kakaoMapRef.current) {
         const {
           center: { lat, lng },
@@ -75,7 +77,7 @@ const KakaoMap = () => {
         );
       }
     };
-  }, [kakaoMapOptions, setKakaoMap, randomRestaurant, kakaoMapAddEventListener]);
+  }, []);
 
   return (
     <Box position='relative' width='100%' height='100%'>

--- a/src/components/common/KakaoMap/index.tsx
+++ b/src/components/common/KakaoMap/index.tsx
@@ -5,8 +5,9 @@ import useOperateKakaoMap from 'hooks/kakaoMap/useOperateKakaoMap';
 import useRecommendRandomRestaurant from 'hooks/kakaoMap/useRecommendRandomRestaurant';
 import useClickAway from 'hooks/useClickAway';
 import { useEffect, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { kakaoMapOptionsState } from 'stores/kakaoMap';
+import { kakaoMapAddEventListener, kakaoMapHelpers } from 'utils/helpers/kakaoMap';
 
 import RecommendRandomRestaurantButton from '../Buttons/RecommendRandomRestaurantButton';
 import CurrentLocationButton from './CurrentLocationButton';
@@ -14,14 +15,10 @@ import RandomRestaurantModal from './RandomRestaurantModal';
 import ZoomInButton from './ZoomInButton';
 import ZoomOutButton from './ZoomOutButton';
 
-const KAKAO_MARKER_EVENT_TYPE = {
-  CLICK: 'click',
-};
-
 const KakaoMap = () => {
   const kakaoMapRef = useRef<HTMLDivElement>(null);
-  const { kakaoMap, setKakaoMap, kakaoMapAddEventListener } = useKakaoMapContext();
-  const kakaoMapOptions = useRecoilValue(kakaoMapOptionsState);
+  const { kakaoMap, setKakaoMap } = useKakaoMapContext();
+  const [kakaoMapOptions, setKakaoMapOptions] = useRecoilState(kakaoMapOptionsState);
   const { moveToCurrentLocation, moveToCurrentLocationIsLoading, zoomIn, zoomOut } =
     useOperateKakaoMap();
   const { recommendRandomRestaurant, recommendRandomRestaurantIsLoading } =
@@ -50,8 +47,16 @@ const KakaoMap = () => {
       };
       const createdKakaoMap = new kakao.maps.Map(kakaoMapRef.current, options);
       setKakaoMap(createdKakaoMap);
+
+      // 카카오맵의 상태(level, 위치 등)를 실시간 추적하기 위한 event 등록
+      kakaoMapAddEventListener(createdKakaoMap, 'zoom_changed', () => {
+        setKakaoMapOptions((previousKakaoMapOptions) => ({
+          ...previousKakaoMapOptions,
+          level: kakaoMapHelpers.getLevel(createdKakaoMap),
+        }));
+      });
     });
-  }, [kakaoMap, kakaoMapOptions, setKakaoMap]);
+  }, [kakaoMap, kakaoMapOptions, setKakaoMap, setKakaoMapOptions]);
 
   // 마커 생성
   useEffect(() => {
@@ -62,23 +67,19 @@ const KakaoMap = () => {
     };
 
     randomRestaurant.marker.setMap(kakaoMap);
-    kakaoMapAddEventListener(
-      randomRestaurant.marker,
-      KAKAO_MARKER_EVENT_TYPE.CLICK,
-      handleClickKakaoMapMarker
-    );
+    kakaoMapAddEventListener(randomRestaurant.marker, 'click', handleClickKakaoMapMarker);
 
     return () => {
       if (randomRestaurant.marker) {
         kakao.maps.event.removeListener(
           randomRestaurant.marker,
-          KAKAO_MARKER_EVENT_TYPE.CLICK,
+          'click',
           handleClickKakaoMapMarker
         );
         randomRestaurant.marker.setMap(null);
       }
     };
-  }, [kakaoMap, kakaoMapAddEventListener, randomRestaurant]);
+  }, [kakaoMap, randomRestaurant]);
 
   return (
     <Box position='relative' width='100%' height='100%'>

--- a/src/contexts/kakaoMap/index.tsx
+++ b/src/contexts/kakaoMap/index.tsx
@@ -3,7 +3,6 @@ import {
   Dispatch,
   ReactNode,
   SetStateAction,
-  useCallback,
   useContext,
   useState,
 } from 'react';
@@ -11,17 +10,11 @@ import {
 type KakaoMapContextType = {
   kakaoMap: kakao.maps.Map | null;
   setKakaoMap: Dispatch<SetStateAction<kakao.maps.Map | null>>;
-  kakaoMapAddEventListener: (
-    target: kakao.maps.event.EventTarget,
-    type: string,
-    callback: () => void
-  ) => void;
 };
 
 const KakaoMapContext = createContext<KakaoMapContextType>({
   kakaoMap: null,
   setKakaoMap: () => {},
-  kakaoMapAddEventListener: () => {},
 });
 
 const useKakaoMapContext = () => useContext(KakaoMapContext);
@@ -29,20 +22,9 @@ const useKakaoMapContext = () => useContext(KakaoMapContext);
 export const KakaoMapProvider = ({ children }: { children: ReactNode }) => {
   const [kakaoMap, setKakaoMap] = useState<kakao.maps.Map | null>(null);
 
-  // kakaoMap이 setState에 의해 변경되어도 새로 생성되지 않도록 useCallback 사용
-  // 새로 생성되면 KakaoMap.tsx의 useEffect에서 재귀 발생
-  // kakaoMap setState -> KakaoMapProvider 호출 -> kakaoMapAddEventListener 재생성 -> KakaoMap.tsx의 useEffect 로직 재수행 -> kakaoMap setState -> ... 무한 루프
-  const kakaoMapAddEventListener = useCallback(
-    (target: kakao.maps.event.EventTarget, type: string, callback: () => void) => {
-      kakao.maps.event.addListener(target, type, callback);
-    },
-    []
-  );
-
   const value = {
     kakaoMap,
     setKakaoMap,
-    kakaoMapAddEventListener,
   };
 
   return <KakaoMapContext.Provider value={value}>{children}</KakaoMapContext.Provider>;

--- a/src/hooks/kakaoMap/useOperateKakaoMap.ts
+++ b/src/hooks/kakaoMap/useOperateKakaoMap.ts
@@ -22,6 +22,7 @@ const useOperateKakaoMap = () => {
   });
   const { kakaoMap } = useKakaoMapContext();
 
+  // 현재 위치로 카카오맵을 이동
   const moveToCurrentLocation = () => {
     const successCallback: PositionCallback = ({ coords: { latitude, longitude } }) => {
       if (!kakaoMap) return;
@@ -59,6 +60,7 @@ const useOperateKakaoMap = () => {
     }
   };
 
+  // 카카오맵 확대
   const zoomIn = () => {
     if (!kakaoMap) return;
     const currentLevel = kakaoMapHelpers.getLevel(kakaoMap);
@@ -80,6 +82,7 @@ const useOperateKakaoMap = () => {
     }));
   };
 
+  // 카카오맵 축소
   const zoomOut = () => {
     if (!kakaoMap) return;
     const currentLevel = kakaoMapHelpers.getLevel(kakaoMap);

--- a/src/hooks/kakaoMap/useOperateKakaoMap.ts
+++ b/src/hooks/kakaoMap/useOperateKakaoMap.ts
@@ -1,7 +1,7 @@
 import { useToast } from '@chakra-ui/react';
 import useKakaoMapContext from 'contexts/kakaoMap';
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { kakaoMapOptionsState } from 'stores/kakaoMap';
 import ERROR_MESSAGE from 'utils/constants/errorMessage';
 import { kakaoMapHelpers } from 'utils/helpers/kakaoMap';
@@ -12,7 +12,7 @@ const DEFAULT_MAX_LEVEL = 12;
 const DEFAULT_TOAST_DURATION = 5000;
 
 const useOperateKakaoMap = () => {
-  const [kakaoMapOptions, setKakaoMapOptions] = useRecoilState(kakaoMapOptionsState);
+  const setKakaoMapOptions = useSetRecoilState(kakaoMapOptionsState);
   const [moveToCurrentLocationIsLoading, setMoveToCurrentLocationIsLoading] =
     useState(false);
   const errorToast = useToast({
@@ -24,6 +24,12 @@ const useOperateKakaoMap = () => {
 
   const moveToCurrentLocation = () => {
     const successCallback: PositionCallback = ({ coords: { latitude, longitude } }) => {
+      if (!kakaoMap) return;
+      kakaoMapHelpers.panto({
+        kakaoMap,
+        latitude,
+        longitude,
+      });
       setKakaoMapOptions((previousKakaoMapOptions) => ({
         ...previousKakaoMapOptions,
         center: {
@@ -54,40 +60,44 @@ const useOperateKakaoMap = () => {
   };
 
   const zoomIn = () => {
-    const currentLevel = kakaoMapOptions.level;
+    if (!kakaoMap) return;
+    const currentLevel = kakaoMapHelpers.getLevel(kakaoMap);
 
     if (currentLevel <= DEFAULT_MIN_LEVEL) return;
-    if (!kakaoMap) return;
-
+    kakaoMapHelpers.setLevel({
+      kakaoMap,
+      nextLevel: currentLevel - 1,
+    });
     const { latitude: currentLatitude, longitude: currentLongitude } =
       kakaoMapHelpers.getCenter(kakaoMap);
-
     setKakaoMapOptions((previousKakaoMapOptions) => ({
       ...previousKakaoMapOptions,
       center: {
         lat: currentLatitude,
         lng: currentLongitude,
       },
-      level: previousKakaoMapOptions.level - 1,
+      level: currentLevel - 1,
     }));
   };
 
   const zoomOut = () => {
-    const currentLevel = kakaoMapOptions.level;
+    if (!kakaoMap) return;
+    const currentLevel = kakaoMapHelpers.getLevel(kakaoMap);
 
     if (currentLevel >= DEFAULT_MAX_LEVEL) return;
-    if (!kakaoMap) return;
-
+    kakaoMapHelpers.setLevel({
+      kakaoMap,
+      nextLevel: currentLevel + 1,
+    });
     const { latitude: currentLatitude, longitude: currentLongitude } =
       kakaoMapHelpers.getCenter(kakaoMap);
-
     setKakaoMapOptions((previousKakaoMapOptions) => ({
       ...previousKakaoMapOptions,
       center: {
         lat: currentLatitude,
         lng: currentLongitude,
       },
-      level: previousKakaoMapOptions.level + 1,
+      level: currentLevel + 1,
     }));
   };
 

--- a/src/utils/helpers/kakaoMap.ts
+++ b/src/utils/helpers/kakaoMap.ts
@@ -1,3 +1,23 @@
+/**
+ * https://apis.map.kakao.com/web/documentation/
+ * 위 링크에서 Docs의 Events 항목에 나오는 이벤트 타입들을 참고하여 KakaoMapEventType 지정.
+ */
+type KakaoMapEventType =
+  | 'center_changed'
+  | 'zoom_start'
+  | 'zoom_changed'
+  | 'bounds_changed'
+  | 'click'
+  | 'dblclick'
+  | 'rightclick'
+  | 'mousemove'
+  | 'dragstart'
+  | 'drag'
+  | 'dragend'
+  | 'idle'
+  | 'tilesloaded'
+  | 'maptypeid_changed';
+
 export const kakaoMapHelpers = {
   panto: ({
     kakaoMap,
@@ -24,4 +44,12 @@ export const kakaoMapHelpers = {
   }) => {
     kakaoMap.setLevel(nextLevel);
   },
+};
+
+export const kakaoMapAddEventListener = (
+  eventTarget: kakao.maps.event.EventTarget,
+  type: KakaoMapEventType,
+  callback: () => void
+) => {
+  kakao.maps.event.addListener(eventTarget, type, callback);
 };

--- a/src/utils/helpers/kakaoMap.ts
+++ b/src/utils/helpers/kakaoMap.ts
@@ -1,6 +1,27 @@
 export const kakaoMapHelpers = {
+  panto: ({
+    kakaoMap,
+    latitude,
+    longitude,
+  }: {
+    kakaoMap: kakao.maps.Map;
+    latitude: number;
+    longitude: number;
+  }) => {
+    kakaoMap.panTo(new kakao.maps.LatLng(latitude, longitude));
+  },
   getCenter: (kakaoMap: kakao.maps.Map) => ({
     latitude: kakaoMap.getCenter().getLat(),
     longitude: kakaoMap.getCenter().getLng(),
   }),
+  getLevel: (kakaoMap: kakao.maps.Map) => kakaoMap.getLevel(),
+  setLevel: ({
+    kakaoMap,
+    nextLevel,
+  }: {
+    kakaoMap: kakao.maps.Map;
+    nextLevel: number;
+  }) => {
+    kakaoMap.setLevel(nextLevel);
+  },
 };


### PR DESCRIPTION
## 💡 Linked Issues

- close #35

## 📖 구현 내용

- 카카오맵 객체가 쌓이지 않고 현재 위치 이동, zoom in/out 되도록 변경

### 제가 하고 있는 방식
- 현재 카카오맵에 대한 데이터 얻기
  a. context로 관리 중인 kakaoMap으로 얻는다. ex) getCenter, getLevel 등
  b. recoil로 관리 중인 kakaoMapOptions에서 얻는다.

## 🖼 구현 이미지

- gif 파일이 크니까 안 올라가네요...

## ✅ PR 포인트 & 궁금한 점

- 현재 카카오맵에 대한 데이터 얻기는 2가지 방식으로 관리 중입니다.
  - 처음엔 kakaoMapOptions에 따라 지도가 리렌더링 되게 해서 화면을 바꾸는 식이었는데, 이렇게 하면 카카오맵 객체가 쌓여서 사용자 경험이 나빠지게 되었습니다.
  - 현재는 하나로 통일할 필요가 있는데, 근데 가지고 있어도 괜찮겠다는 생각이 현재는 들어서 일단 유지 중입니다.
- kakaoMapHelpers라는 메서드가 생겼습니다. kakao map 객체에서 getCenter 메서드를 통해 현재 위치를 가져올 수 있는데 latitude, longitude를 그대로 뱉는게 아니라 kakao.maps.LatLng 객체를 뱉어냅니다. latitude, longitude를 가져오려면 여기에서 getLat, getLng를 또 해줘야 합니다. 이 과정을 추상화하는게 좋다고 판단해서 kakaoMapHelpers라는 하나의 랩핑 함수를 만들었습니다.
  - 일관성을 위해서는 getCenter, getLevel, setCenter 등 kakao map의 메서드를 kakaoMapHelpers에 다 넣어서 쓰는게 좋겠다는 생각이 듭니다.
- 수화님 동영상 어캐하신거죠..?
