### PR TITLE
queryKey 상수화 위치 변경 

### DIFF
--- a/src/hooks/query/useUser.ts
+++ b/src/hooks/query/useUser.ts
@@ -1,16 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchUser } from 'services/user';
-import { QUERY_KEY_USER } from 'utils/constants/queryKeys';
+import QUERY_KEYS from 'utils/constants/queryKeys';
 
 // custom hooks(컴포넌트에 바인딩해서 사용)
-const useGetUser = () => {
+export const useGetUser = () => {
   return useQuery({
-    queryKey: [QUERY_KEY_USER.user],
+    queryKey: [QUERY_KEYS.USER.MY_INFO],
     queryFn: fetchUser,
     staleTime: 10000,
     suspense: true,
     refetchOnWindowFocus: false,
   });
 };
-
-export { useGetUser };

--- a/src/hooks/query/useUser.ts
+++ b/src/hooks/query/useUser.ts
@@ -1,15 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchUser } from 'services/user';
+import { QUERY_KEY_USER } from 'utils/constants/queryKeys';
 
-// 1. query key 상수화(export 안함. 여기서만 쓸 것)
-const QUERY_KEY = {
-  user: 'user',
-};
-
-// 2. custom hooks(외부에서 사용)
+// custom hooks(컴포넌트에 바인딩해서 사용)
 const useGetUser = () => {
   return useQuery({
-    queryKey: [QUERY_KEY.user],
+    queryKey: [QUERY_KEY_USER.user],
     queryFn: fetchUser,
     staleTime: 10000,
     suspense: true,

--- a/src/utils/constants/errorMessage.ts
+++ b/src/utils/constants/errorMessage.ts
@@ -6,6 +6,6 @@ const ERROR_MESSAGE = {
   // https://apis.map.kakao.com/web/documentation/#services_Status
   // 위 문서 확인 시, ERROR 코드는 카카오맵 서버에 문제가 있을 시 발생함.
   REQUEST_FAILED_BY_KAKAO_MAP_SERVER_ERROR: '카카오맵 서버 에러로 요청이 실패했습니다.',
-};
+} as const;
 
 export default ERROR_MESSAGE;

--- a/src/utils/constants/queryKeys.ts
+++ b/src/utils/constants/queryKeys.ts
@@ -1,3 +1,7 @@
-export const QUERY_KEY_USER = {
-  user: 'user',
+const QUERY_KEYS = {
+  USER: {
+    MY_INFO: 'my-info',
+  },
 } as const;
+
+export default QUERY_KEYS;

--- a/src/utils/constants/queryKeys.ts
+++ b/src/utils/constants/queryKeys.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEY_USER = {
+  user: 'user',
+} as const;


### PR DESCRIPTION
## 💡 Linked Issues

- close #91 

## 📖 구현 내용

> **작업배경** 
queryKey를 hooks/query에서 상수화하고, 해당 파일엔서만 쓰도록 했는데..ssr을 할 경우, query key가 필요하기 때문에! queryKey를 utils/constants/querykeys.ts에 두고 Import/export 하기로 정해짐

- querykey 정한 위치로 이동 
- constanst 파일의 변수, as const 키워드로 상수화함! 


## ✅ PR 포인트 & 궁금한 점
- 네이밍 괜찮나요? QUERY_KEY_DOMAIN 이렇게 가는 게 좋을 거 같아서, QUERY_KEY_USER 이라고 해뒀습니다! 

## ❤️‍🔥 react-query layer 정리 
다시 정리하자면,  
- `user.ts` : 유저 관련 api 호출하는 곳(GET user, POST user, ...) 
- `useUser.ts` :유저관련 api를 사용해, 비즈니스 로직 적는 곳(사용자 프로필 변경 시, query에 있는 사용자 정보 지우고, 새로운 값 받아오는 등의 로직) 
- `queryKeys.ts` > QUERY_KEY_USER : queryKey를 적는 공간 

제가 정리한 layer에 대해 의견있으면 자유롭게 해주시면 되고, 저희가 쓸 때 편한구조로 바꿔가도 좋아용 

