### PR TITLE
밥모임 신청 로직, 밥모임 상태 변경 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@next/font": "13.1.6",
+        "@stomp/stompjs": "^7.0.0",
         "@tanstack/react-query": "^4.24.6",
         "@tanstack/react-query-devtools": "^4.24.6",
         "@types/moment": "^2.13.0",
@@ -32,6 +33,7 @@
         "react-hook-form": "^7.43.2",
         "react-icons": "^4.7.1",
         "recoil": "^0.7.6",
+        "sockjs-client": "^1.6.1",
         "typescript": "4.9.5"
       },
       "devDependencies": {
@@ -42,6 +44,7 @@
         "@types/google.maps": "^3.52.0",
         "@types/jsonwebtoken": "^9.0.1",
         "@types/react-calendar": "^3.9.0",
+        "@types/sockjs-client": "^1.5.1",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "eslint-config-prettier": "^8.6.0",
@@ -2764,6 +2767,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.0.0.tgz",
+      "integrity": "sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw=="
+    },
     "node_modules/@stylelint/postcss-css-in-js": {
       "version": "0.38.0",
       "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.38.0.tgz",
@@ -2999,6 +3007,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.1.tgz",
+      "integrity": "sha512-bmZM6A1GPdjF0bcuIUC+50hZEMGkzMsiG9by6X9U+7IZFOiPtz7MJ9h05FSpPVxlj4i+TzzoG3ESo1FJlbLb6A==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4962,6 +4976,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
@@ -5047,6 +5069,17 @@
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5683,6 +5716,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "node_modules/human-signals": {
       "version": "3.0.1",
@@ -7465,6 +7503,11 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7975,6 +8018,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -8228,6 +8276,32 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map": {
@@ -8998,6 +9072,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
@@ -9073,6 +9156,27 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@next/font": "13.1.6",
+    "@stomp/stompjs": "^7.0.0",
     "@tanstack/react-query": "^4.24.6",
     "@tanstack/react-query-devtools": "^4.24.6",
     "@types/moment": "^2.13.0",
@@ -34,6 +35,7 @@
     "react-hook-form": "^7.43.2",
     "react-icons": "^4.7.1",
     "recoil": "^0.7.6",
+    "sockjs-client": "^1.6.1",
     "typescript": "4.9.5"
   },
   "devDependencies": {
@@ -44,6 +46,7 @@
     "@types/google.maps": "^3.52.0",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/react-calendar": "^3.9.0",
+    "@types/sockjs-client": "^1.5.1",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "eslint-config-prettier": "^8.6.0",

--- a/src/components/FoodParty/FoodPartyApplicationDrawer.tsx
+++ b/src/components/FoodParty/FoodPartyApplicationDrawer.tsx
@@ -30,7 +30,6 @@ const FoodPartyApplicationDrawer = ({
 }: FoodPartyApplicationDrawerProps) => {
   const { register, handleSubmit } = useForm<FormType>();
   const onSubmit = (data: FormType) => {
-    /**Todo: 신청서 Submit 동작 */
     onClickSubmitButton(data.text, {
       onSuccess: () => {
         onClose();

--- a/src/components/FoodParty/FoodPartyApplicationDrawer.tsx
+++ b/src/components/FoodParty/FoodPartyApplicationDrawer.tsx
@@ -1,4 +1,6 @@
 import { Flex, FormControl, FormLabel, Text, Textarea } from '@chakra-ui/react';
+import { UseMutateFunction } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
 import BottomDrawer from 'components/common/BottomDrawer';
 import Button from 'components/common/Button';
 import Image from 'next/image';
@@ -7,7 +9,14 @@ import { useForm } from 'react-hook-form';
 type FoodPartyApplicationDrawerProps = {
   isOpen: boolean;
   onClose: () => void;
-  onClickSubmitButton: () => void;
+  onClickSubmitButton: UseMutateFunction<
+    {
+      id: number;
+    },
+    unknown,
+    string,
+    unknown
+  >;
 };
 
 type FormType = {
@@ -22,6 +31,11 @@ const FoodPartyApplicationDrawer = ({
   const { register, handleSubmit } = useForm<FormType>();
   const onSubmit = (data: FormType) => {
     /**Todo: 신청서 Submit 동작 */
+    onClickSubmitButton(data.text, {
+      onSuccess: () => {
+        onClose();
+      },
+    });
   };
 
   return (
@@ -53,7 +67,7 @@ const FoodPartyApplicationDrawer = ({
           />
           <Button
             type='submit'
-            onClick={onClickSubmitButton}
+            onClick={handleSubmit(onSubmit)}
             style={{
               background: 'primary',
               marginTop: '1rem',

--- a/src/components/FoodParty/FoodPartyApplicationDrawer.tsx
+++ b/src/components/FoodParty/FoodPartyApplicationDrawer.tsx
@@ -1,6 +1,5 @@
 import { Flex, FormControl, FormLabel, Text, Textarea } from '@chakra-ui/react';
 import { UseMutateFunction } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
 import BottomDrawer from 'components/common/BottomDrawer';
 import Button from 'components/common/Button';
 import Image from 'next/image';

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton.tsx
@@ -1,12 +1,16 @@
 import { Button } from '@chakra-ui/react';
-import { FoodPartyStatus } from 'types/foodParty';
+import { FoodPartyDetailChangeStatusButtonText, FoodPartyStatus } from 'types/foodParty';
+import {
+  checkButtonTextIsDisabled,
+  getFoodPartyDetailChangeStatusButtonText,
+} from 'utils/helpers/foodParty';
 
 type FoodPartyDetailChangeStatusButtonProps = {
   isLeader: boolean;
   isMember: boolean;
   isFull: boolean;
   status: FoodPartyStatus;
-  // onClick: () => void;
+  onClick: (buttonText: FoodPartyDetailChangeStatusButtonText) => void;
 };
 
 const FoodPartyDetailChangeStatusButton = ({
@@ -14,16 +18,23 @@ const FoodPartyDetailChangeStatusButton = ({
   isMember,
   isFull,
   status,
-}: // onClick,
-FoodPartyDetailChangeStatusButtonProps) => {
-  const buttonText = getText(isLeader, isMember, isFull, status);
+  onClick,
+}: FoodPartyDetailChangeStatusButtonProps) => {
+  const buttonText = getFoodPartyDetailChangeStatusButtonText(
+    isLeader,
+    isMember,
+    isFull,
+    status
+  );
   const isDisabled = checkButtonTextIsDisabled(buttonText);
 
   return (
     <>
       {buttonText !== '' && (
         <Button
-          // onClick={onClick}
+          onClick={() => {
+            onClick(buttonText);
+          }}
           disabled={isDisabled}
           position='absolute'
           left='50%'
@@ -44,44 +55,3 @@ FoodPartyDetailChangeStatusButtonProps) => {
 };
 
 export default FoodPartyDetailChangeStatusButton;
-
-const LeaderText = {
-  모집중: '모집 완료했끼니?',
-  '모집 완료': '식사를 완료했끼니?',
-  '식사 완료': '리뷰 작성하러 갈끼니?',
-};
-
-const MemberText = {
-  모집중: '',
-  '모집 완료': '',
-  '식사 완료': '리뷰 작성하러 갈끼니?',
-};
-
-const NotMemberText = {
-  모집중: '참여할 끼니?',
-  '모집 완료': '모집이 완료되버렸끼니!',
-  '식사 완료': '',
-};
-
-const getText = (
-  isLeader: boolean,
-  isMember: boolean,
-  isFull: boolean,
-  status: FoodPartyStatus
-) => {
-  // 방장인 경우
-  if (isLeader) return LeaderText[status];
-
-  // 멤버인 경우
-  if (isMember) return MemberText[status];
-
-  // 참여하지 않은 경우
-  if (isFull) return '인원이 꽉 차버렸끼니!';
-  return NotMemberText[status];
-};
-
-const checkButtonTextIsDisabled = (buttonText: string) => {
-  return (
-    buttonText === '인원이 꽉 차버렸끼니!' || buttonText === '모집이 완료되버렸끼니!'
-  );
-};

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton.tsx
@@ -46,19 +46,19 @@ FoodPartyDetailChangeStatusButtonProps) => {
 export default FoodPartyDetailChangeStatusButton;
 
 const LeaderText = {
-  '모집 중': '출발할 끼니?',
+  모집중: '모집 완료했끼니?',
   '모집 완료': '식사를 완료했끼니?',
   '식사 완료': '리뷰 작성하러 갈끼니?',
 };
 
 const MemberText = {
-  '모집 중': '',
+  모집중: '',
   '모집 완료': '',
   '식사 완료': '리뷰 작성하러 갈끼니?',
 };
 
 const NotMemberText = {
-  '모집 중': '참여할 끼니?',
+  모집중: '참여할 끼니?',
   '모집 완료': '모집이 완료되버렸끼니!',
   '식사 완료': '',
 };

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailContent.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailContent.tsx
@@ -1,0 +1,41 @@
+import { Button, Flex, Text } from '@chakra-ui/react';
+import { AiOutlineCalendar, AiOutlineClockCircle, AiOutlineSearch } from 'react-icons/ai';
+import { templatePromiseDate, templatePromiseTime } from 'utils/helpers/foodParty';
+
+type FoodPartyDetailContentProps = {
+  promiseTime: number[];
+  content: string;
+  onClick: () => void;
+};
+
+const FoodPartyDetailContent = ({
+  promiseTime,
+  content,
+  onClick,
+}: FoodPartyDetailContentProps) => {
+  const [year, month, day, hour, minute] = promiseTime;
+
+  return (
+    <>
+      <Flex flexDirection='column' gap='0.5rem'>
+        <Flex alignItems='center' gap='0.5rem'>
+          <AiOutlineCalendar />
+          <Text>{templatePromiseDate(year, month, day)}</Text>
+        </Flex>
+        <Flex alignItems='center' gap='0.5rem'>
+          <AiOutlineClockCircle />
+          <Text>{templatePromiseTime(hour, minute)}</Text>
+        </Flex>
+        <Flex alignItems='center' gap='0.5rem'>
+          <AiOutlineSearch />
+          <Button onClick={onClick} height='1.5rem'>
+            맛집 정보
+          </Button>
+        </Flex>
+      </Flex>
+      <Text margin='1rem 0'>{content}</Text>
+    </>
+  );
+};
+
+export default FoodPartyDetailContent;

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailHeader.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailHeader.tsx
@@ -1,0 +1,27 @@
+import { Divider, Flex, Heading, Stack } from '@chakra-ui/react';
+import Category from 'components/common/Category';
+
+type FoodPartyDetailHeaderProps = {
+  status: string;
+  category: string;
+  foodPartyName: string;
+};
+
+const FoodPartyDetailHeader = ({
+  status,
+  category,
+  foodPartyName,
+}: FoodPartyDetailHeaderProps) => {
+  return (
+    <Flex flexDirection='column' gap='0.5rem'>
+      <Stack direction='row'>
+        <Category>{status}</Category>
+        <Category>{category}</Category>
+      </Stack>
+      <Heading as='h1'>{foodPartyName}</Heading>
+      <Divider />
+    </Flex>
+  );
+};
+
+export default FoodPartyDetailHeader;

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailHeader.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailHeader.tsx
@@ -1,8 +1,11 @@
 import { Divider, Flex, Heading, Stack } from '@chakra-ui/react';
 import Category from 'components/common/Category';
+import { FoodPartyStatus } from 'types/foodParty';
+
+import FoodPartyDetailStatusCategory from './FoodPartyDetailStatusCategory';
 
 type FoodPartyDetailHeaderProps = {
-  status: string;
+  status: FoodPartyStatus;
   category: string;
   foodPartyName: string;
 };
@@ -15,7 +18,7 @@ const FoodPartyDetailHeader = ({
   return (
     <Flex flexDirection='column' gap='0.5rem'>
       <Stack direction='row'>
-        <Category>{status}</Category>
+        <FoodPartyDetailStatusCategory status={status} />
         <Category>{category}</Category>
       </Stack>
       <Heading as='h1'>{foodPartyName}</Heading>

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusButton.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusButton.tsx
@@ -37,7 +37,7 @@ const FoodPartyDetailStatusButton = ({
 
   return (
     <>
-      {buttonText !== '' && (
+      {buttonText && (
         <Button
           onClick={() => {
             onClick(buttonText);

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusButton.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusButton.tsx
@@ -1,26 +1,26 @@
 import { Button } from '@chakra-ui/react';
-import { FoodPartyDetailChangeStatusButtonText, FoodPartyStatus } from 'types/foodParty';
+import { FoodPartyDetailStatusButtonText, FoodPartyStatus } from 'types/foodParty';
 import {
   checkButtonTextIsDisabled,
-  getFoodPartyDetailChangeStatusButtonText,
+  getFoodPartyDetailStatusButtonText,
 } from 'utils/helpers/foodParty';
 
-type FoodPartyDetailChangeStatusButtonProps = {
+type FoodPartyDetailStatusButtonProps = {
   isLeader: boolean;
   isMember: boolean;
   isFull: boolean;
   status: FoodPartyStatus;
-  onClick: (buttonText: FoodPartyDetailChangeStatusButtonText) => void;
+  onClick: (buttonText: FoodPartyDetailStatusButtonText) => void;
 };
 
-const FoodPartyDetailChangeStatusButton = ({
+const FoodPartyDetailStatusButton = ({
   isLeader,
   isMember,
   isFull,
   status,
   onClick,
-}: FoodPartyDetailChangeStatusButtonProps) => {
-  const buttonText = getFoodPartyDetailChangeStatusButtonText(
+}: FoodPartyDetailStatusButtonProps) => {
+  const buttonText = getFoodPartyDetailStatusButtonText(
     isLeader,
     isMember,
     isFull,
@@ -54,4 +54,4 @@ const FoodPartyDetailChangeStatusButton = ({
   );
 };
 
-export default FoodPartyDetailChangeStatusButton;
+export default FoodPartyDetailStatusButton;

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusButton.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusButton.tsx
@@ -1,11 +1,16 @@
 import { Button } from '@chakra-ui/react';
-import { FoodPartyDetailStatusButtonText, FoodPartyStatus } from 'types/foodParty';
+import {
+  FoodPartyDetailStatusButtonText,
+  FoodPartyStatus,
+  ProposalStatus,
+} from 'types/foodParty';
 import {
   checkButtonTextIsDisabled,
   getFoodPartyDetailStatusButtonText,
 } from 'utils/helpers/foodParty';
 
 type FoodPartyDetailStatusButtonProps = {
+  applied: ProposalStatus;
   isLeader: boolean;
   isMember: boolean;
   isFull: boolean;
@@ -14,6 +19,7 @@ type FoodPartyDetailStatusButtonProps = {
 };
 
 const FoodPartyDetailStatusButton = ({
+  applied,
   isLeader,
   isMember,
   isFull,
@@ -21,6 +27,7 @@ const FoodPartyDetailStatusButton = ({
   onClick,
 }: FoodPartyDetailStatusButtonProps) => {
   const buttonText = getFoodPartyDetailStatusButtonText(
+    applied,
     isLeader,
     isMember,
     isFull,

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusCategory.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusCategory.tsx
@@ -1,0 +1,8 @@
+import Category from 'components/common/Category';
+import { FoodPartyStatus } from 'types/foodParty';
+
+const FoodPartyDetailStatusCategory = ({ status }: { status: FoodPartyStatus }) => {
+  return <Category foodPartyDetailStatus={status}>{status}</Category>;
+};
+
+export default FoodPartyDetailStatusCategory;

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusCategory.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusCategory.tsx
@@ -1,8 +1,23 @@
 import Category from 'components/common/Category';
 import { FoodPartyStatus } from 'types/foodParty';
 
+const FOOD_PARTY_DETAIL_STATUS_COLORS: {
+  [key: string]: string;
+  '모집 중': string;
+  '모집 종료': string;
+  '식사 완료': string;
+} = {
+  '모집 중': 'lightgreen',
+  '모집 종료': 'orange',
+  '식사 완료': 'lightgray',
+};
+
 const FoodPartyDetailStatusCategory = ({ status }: { status: FoodPartyStatus }) => {
-  return <Category foodPartyDetailStatus={status}>{status}</Category>;
+  return (
+    <Category backgroundColor={FOOD_PARTY_DETAIL_STATUS_COLORS[status]}>
+      {status}
+    </Category>
+  );
 };
 
 export default FoodPartyDetailStatusCategory;

--- a/src/components/FoodParty/FoodPartyDetail/FoodPartyMemberList.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/FoodPartyMemberList.tsx
@@ -1,24 +1,29 @@
-import { Flex, Heading, Text } from '@chakra-ui/react';
+import { Button, Flex, Heading, Stack, Text } from '@chakra-ui/react';
 import { Member } from 'types/foodParty';
 
 import FoodPartyMemberItem from './FoodPartyMemberItem';
 
 const FoodPartyMemberList = ({
+  onClickChatButton,
   memberList,
   capacity,
 }: {
+  onClickChatButton?: () => void;
   memberList: Member[];
   capacity: number;
 }) => {
   return (
     <Flex flexDirection='column'>
-      <Flex alignItems='center' gap='0.5rem'>
-        <Heading as='h2' size='md' margin='1rem 0'>
-          끼니원들
-        </Heading>
-        <Text fontSize='sm'>
-          {memberList.length} / {capacity}
-        </Text>
+      <Flex justifyContent='space-between' alignItems='center'>
+        <Flex alignItems='center' gap='0.5rem'>
+          <Heading as='h2' size='md' margin='1rem 0'>
+            끼니원들
+          </Heading>
+          <Text fontSize='sm'>
+            {memberList.length} / {capacity}
+          </Text>
+        </Flex>
+        {onClickChatButton && <Button onClick={onClickChatButton}>채팅방</Button>}
       </Flex>
       <Flex flexDirection='column' gap='0.5rem'>
         {memberList.map((member) => (

--- a/src/components/FoodParty/FoodPartyList.tsx
+++ b/src/components/FoodParty/FoodPartyList.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { Button, Flex, Text } from '@chakra-ui/react';
 import { FoodParty } from 'types/foodParty';
 
 import FoodPartyListItem from './FoodPartyListItem';
@@ -7,18 +7,32 @@ type FoodPartyListProps = {
   foodPartyList: FoodParty[];
   onClickViewButton: (partyId: number) => void;
   onClickReviewButton?: (partyId: number) => void;
+  onClickCreateFoodPartyButton?: () => void;
 };
 
 const FoodPartyList = ({
   foodPartyList,
   onClickViewButton,
   onClickReviewButton,
+  onClickCreateFoodPartyButton,
 }: FoodPartyListProps) => {
   return (
     <>
       {!foodPartyList.length ? (
         // To Do: 스타일링 by 승준
-        <Text>밥모임이 없어요..!</Text>
+        <Flex
+          flexDirection='column'
+          position='absolute'
+          alignItems='center'
+          gap='1rem'
+          top='50%'
+          left='50%'
+          transform='translate(-50%, -50%)'>
+          <Text>밥모임이 없어요..!</Text>
+          {onClickCreateFoodPartyButton && (
+            <Button onClick={onClickCreateFoodPartyButton}>밥모임 생성하러 가기</Button>
+          )}
+        </Flex>
       ) : (
         <Flex flexDirection='column'>
           {foodPartyList?.map((party) => (

--- a/src/components/FoodParty/FoodPartyList.tsx
+++ b/src/components/FoodParty/FoodPartyList.tsx
@@ -1,14 +1,19 @@
 import { Flex, Text } from '@chakra-ui/react';
-import { FoodParty, FoodPartyStatus } from 'types/foodParty';
+import { FoodParty } from 'types/foodParty';
 
 import FoodPartyListItem from './FoodPartyListItem';
 
 type FoodPartyListProps = {
   foodPartyList: FoodParty[];
-  onClick: (partyId: number) => void;
+  onClickViewButton: (partyId: number) => void;
+  onClickReviewButton: (partyId: number) => void;
 };
 
-const FoodPartyList = ({ foodPartyList, onClick }: FoodPartyListProps) => {
+const FoodPartyList = ({
+  foodPartyList,
+  onClickViewButton,
+  onClickReviewButton,
+}: FoodPartyListProps) => {
   return (
     <>
       {!foodPartyList.length ? (
@@ -18,7 +23,12 @@ const FoodPartyList = ({ foodPartyList, onClick }: FoodPartyListProps) => {
       ) : (
         <Flex flexDirection='column'>
           {foodPartyList?.map((party) => (
-            <FoodPartyListItem key={party.id} party={party} onClick={onClick} />
+            <FoodPartyListItem
+              key={party.id}
+              party={party}
+              onClickViewButton={onClickViewButton}
+              onClickReviewButton={onClickReviewButton}
+            />
           ))}
         </Flex>
       )}

--- a/src/components/FoodParty/FoodPartyList.tsx
+++ b/src/components/FoodParty/FoodPartyList.tsx
@@ -6,7 +6,7 @@ import FoodPartyListItem from './FoodPartyListItem';
 type FoodPartyListProps = {
   foodPartyList: FoodParty[];
   onClickViewButton: (partyId: number) => void;
-  onClickReviewButton: (partyId: number) => void;
+  onClickReviewButton?: (partyId: number) => void;
 };
 
 const FoodPartyList = ({

--- a/src/components/FoodParty/FoodPartyList.tsx
+++ b/src/components/FoodParty/FoodPartyList.tsx
@@ -17,9 +17,8 @@ const FoodPartyList = ({
   return (
     <>
       {!foodPartyList.length ? (
-        <Text>
-          아직 밥모임에 참여해보신 적이 없으시군요, 직접 밥모임을 생성해볼까요!?
-        </Text>
+        // To Do: 스타일링 by 승준
+        <Text>밥모임이 없어요..!</Text>
       ) : (
         <Flex flexDirection='column'>
           {foodPartyList?.map((party) => (

--- a/src/components/FoodParty/FoodPartyListItem.tsx
+++ b/src/components/FoodParty/FoodPartyListItem.tsx
@@ -11,6 +11,8 @@ import Category from 'components/common/Category';
 import { FoodParty } from 'types/foodParty';
 import { templatePromiseDate, templatePromiseTime } from 'utils/helpers/foodParty';
 
+import FoodPartyDetailStatusCategory from './FoodPartyDetail/FoodPartyDetailStatusCategory';
+
 const DEFAULT_AVATAR_GROUP_MAX_VALUE = 3;
 
 type FoodPartyListItemProps = {
@@ -36,7 +38,7 @@ const FoodPartyListItem = ({
       marginBottom='1rem'>
       <Flex flexDirection='column' gap='0.5rem'>
         <Stack direction='row'>
-          <Category>{party.crewStatus}</Category>
+          <FoodPartyDetailStatusCategory status={party.crewStatus} />
           <Category>{party.category}</Category>
         </Stack>
         <Text>{party.name}</Text>

--- a/src/components/FoodParty/FoodPartyListItem.tsx
+++ b/src/components/FoodParty/FoodPartyListItem.tsx
@@ -36,7 +36,7 @@ const FoodPartyListItem = ({
       marginBottom='1rem'>
       <Flex flexDirection='column' gap='0.5rem'>
         <Stack direction='row'>
-          <Category>{party.status}</Category>
+          <Category>{party.crewStatus}</Category>
           <Category>{party.category}</Category>
         </Stack>
         <Text>{party.name}</Text>
@@ -57,7 +57,7 @@ const FoodPartyListItem = ({
           ))}
         </AvatarGroup>
         <Flex alignItems='center' gap='0.5rem'>
-          {party.status === '식사 완료' && (
+          {party.crewStatus === '식사 완료' && (
             <Button
               onClick={() => {
                 onClickReviewButton && onClickReviewButton(party.id);

--- a/src/components/FoodParty/FoodPartyListItem.tsx
+++ b/src/components/FoodParty/FoodPartyListItem.tsx
@@ -13,13 +13,17 @@ import { templatePromiseDate, templatePromiseTime } from 'utils/helpers/foodPart
 
 const DEFAULT_AVATAR_GROUP_MAX_VALUE = 3;
 
+type FoodPartyListItemProps = {
+  party: FoodParty;
+  onClickViewButton: (partyId: number) => void;
+  onClickReviewButton: (partyId: number) => void;
+};
+
 const FoodPartyListItem = ({
   party,
-  onClick,
-}: {
-  party: FoodParty;
-  onClick: (partyId: number) => void;
-}) => {
+  onClickViewButton,
+  onClickReviewButton,
+}: FoodPartyListItemProps) => {
   const [year, month, day, hour, minute] = party.promiseTime;
 
   return (
@@ -52,12 +56,22 @@ const FoodPartyListItem = ({
             <Avatar key={member.userId} src={member.profileImgUrl} />
           ))}
         </AvatarGroup>
-        <Button
-          onClick={() => {
-            onClick(party.id);
-          }}>
-          View
-        </Button>
+        <Flex alignItems='center'>
+          {party.status === '식사 완료' && (
+            <Button
+              onClick={() => {
+                onClickReviewButton(party.id);
+              }}>
+              Review
+            </Button>
+          )}
+          <Button
+            onClick={() => {
+              onClickViewButton(party.id);
+            }}>
+            View
+          </Button>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/src/components/FoodParty/FoodPartyListItem.tsx
+++ b/src/components/FoodParty/FoodPartyListItem.tsx
@@ -16,7 +16,7 @@ const DEFAULT_AVATAR_GROUP_MAX_VALUE = 3;
 type FoodPartyListItemProps = {
   party: FoodParty;
   onClickViewButton: (partyId: number) => void;
-  onClickReviewButton: (partyId: number) => void;
+  onClickReviewButton?: (partyId: number) => void;
 };
 
 const FoodPartyListItem = ({
@@ -60,7 +60,7 @@ const FoodPartyListItem = ({
           {party.status === '식사 완료' && (
             <Button
               onClick={() => {
-                onClickReviewButton(party.id);
+                onClickReviewButton && onClickReviewButton(party.id);
               }}>
               Review
             </Button>

--- a/src/components/FoodParty/FoodPartyListItem.tsx
+++ b/src/components/FoodParty/FoodPartyListItem.tsx
@@ -56,7 +56,7 @@ const FoodPartyListItem = ({
             <Avatar key={member.userId} src={member.profileImgUrl} />
           ))}
         </AvatarGroup>
-        <Flex alignItems='center'>
+        <Flex alignItems='center' gap='0.5rem'>
           {party.status === '식사 완료' && (
             <Button
               onClick={() => {

--- a/src/components/common/Category.tsx
+++ b/src/components/common/Category.tsx
@@ -1,9 +1,32 @@
 import { Badge } from '@chakra-ui/react';
 import { ReactNode } from 'react';
+import { FoodPartyStatus } from 'types/foodParty';
 
-const Category = ({ children }: { children: ReactNode }) => {
+type CategoryProps = {
+  children: ReactNode;
+  foodPartyDetailStatus?: FoodPartyStatus;
+};
+
+const Category = ({ children, foodPartyDetailStatus }: CategoryProps) => {
+  let backgroundColor;
+
+  switch (foodPartyDetailStatus) {
+    case '모집 중':
+      backgroundColor = 'lightgreen';
+      break;
+    case '모집 종료':
+      backgroundColor = 'lightyellow';
+      break;
+    case '식사 완료':
+      backgroundColor = 'lightgray';
+      break;
+    default:
+      backgroundColor = 'gray.100';
+      break;
+  }
+
   return (
-    <Badge borderRadius='1.5rem' padding='2px 5px'>
+    <Badge backgroundColor={backgroundColor} borderRadius='1.5rem' padding='2px 5px'>
       {children}
     </Badge>
   );

--- a/src/components/common/Category.tsx
+++ b/src/components/common/Category.tsx
@@ -1,32 +1,19 @@
 import { Badge } from '@chakra-ui/react';
 import { ReactNode } from 'react';
-import { FoodPartyStatus } from 'types/foodParty';
 
 type CategoryProps = {
   children: ReactNode;
-  foodPartyDetailStatus?: FoodPartyStatus;
+  backgroundColor?: string;
 };
 
-const Category = ({ children, foodPartyDetailStatus }: CategoryProps) => {
-  let backgroundColor;
+const CHAKRA_BUTTON_DEFAULT_COLOR = 'gray.100';
 
-  switch (foodPartyDetailStatus) {
-    case '모집 중':
-      backgroundColor = 'lightgreen';
-      break;
-    case '모집 종료':
-      backgroundColor = 'lightyellow';
-      break;
-    case '식사 완료':
-      backgroundColor = 'lightgray';
-      break;
-    default:
-      backgroundColor = 'gray.100';
-      break;
-  }
-
+const Category = ({ children, backgroundColor }: CategoryProps) => {
   return (
-    <Badge backgroundColor={backgroundColor} borderRadius='1.5rem' padding='2px 5px'>
+    <Badge
+      backgroundColor={backgroundColor || CHAKRA_BUTTON_DEFAULT_COLOR}
+      borderRadius='1.5rem'
+      padding='2px 5px'>
       {children}
     </Badge>
   );

--- a/src/components/common/GoHomeWhenErrorInvoked.tsx
+++ b/src/components/common/GoHomeWhenErrorInvoked.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, Text } from '@chakra-ui/react';
 import Link from 'next/link';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
-const GoHomeWhenErrorInvoked = () => {
+const GoHomeWhenErrorInvoked = ({ errorText }: { errorText?: string }) => {
   return (
     <Flex
       position='absolute'
@@ -12,7 +12,7 @@ const GoHomeWhenErrorInvoked = () => {
       flexDirection='column'
       alignItems='center'
       gap='1rem'>
-      <Text>서버에 문제가 발생했습니다.</Text>
+      <Text>{errorText ? errorText : '서버에 에러가 발생했습니다.'}</Text>
       <Link href={ROUTING_PATHS.HOME}>
         <Button>처음으로 돌아가기</Button>
       </Link>

--- a/src/components/common/GoHomeWhenErrorInvoked.tsx
+++ b/src/components/common/GoHomeWhenErrorInvoked.tsx
@@ -1,0 +1,23 @@
+import { Button, Flex, Text } from '@chakra-ui/react';
+import Link from 'next/link';
+import ROUTING_PATHS from 'utils/constants/routingPaths';
+
+const GoHomeWhenErrorInvoked = () => {
+  return (
+    <Flex
+      position='absolute'
+      top='50%'
+      left='50%'
+      transform='translate(-50%, -50%)'
+      flexDirection='column'
+      alignItems='center'
+      gap='1rem'>
+      <Text>서버에 문제가 발생했습니다.</Text>
+      <Link href={ROUTING_PATHS.HOME}>
+        <Button>처음으로 돌아가기</Button>
+      </Link>
+    </Flex>
+  );
+};
+
+export default GoHomeWhenErrorInvoked;

--- a/src/hooks/query/useFoodParty.ts
+++ b/src/hooks/query/useFoodParty.ts
@@ -131,12 +131,14 @@ export const usePostMemberReview = (crewId: string) => {
 };
 
 export const useCreateFoodPartyApplication = (partyId: string, leaderUserId: number) => {
+  const queryClient = useQueryClient();
   const toast = useToast();
 
   return useMutation({
     mutationFn: (content: string) =>
       createFoodPartyApplication(partyId, content, leaderUserId),
     onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEYS.FOOD_PARTY.FOOD_PARTY_DETAIL, partyId]);
       toast({
         title: '신청서가 제출되었습니다.',
         position: 'top',

--- a/src/hooks/query/useFoodParty.ts
+++ b/src/hooks/query/useFoodParty.ts
@@ -14,25 +14,7 @@ import { FoodPartyLeaderReviewBody, FoodPartyMemberReviewBody } from 'types/food
 import QUERY_KEYS from 'utils/constants/queryKeys';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
-export const useCreateFoodParty = () => {
-  const router = useRouter();
-  const toast = useToast();
-  return useMutation({
-    mutationFn: createFoodParty,
-    onSuccess: (data) => {
-      const partyId = data.id;
-      router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL(partyId));
-      toast({
-        title: '밥모임이 생성되었습니다!',
-        description: '생성된 밥모임 정보를 확인하세요',
-        position: 'top',
-        status: 'success',
-        duration: 2000,
-        isClosable: true,
-      });
-    },
-  });
-};
+import { updateFoodPartyStatus } from './../../services/foodParty';
 
 export const useGetMyFoodPartyList = () => {
   return useQuery({
@@ -98,6 +80,27 @@ export const usePostLeaderReview = (crewId: string) => {
   });
 };
 
+export const useCreateFoodParty = () => {
+  const router = useRouter();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: createFoodParty,
+    onSuccess: (data) => {
+      const partyId = data.id;
+      router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL(partyId));
+      toast({
+        title: '밥모임이 생성되었습니다!',
+        description: '생성된 밥모임 정보를 확인하세요',
+        position: 'top',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
+    },
+  });
+};
+
 export const usePostMemberReview = (crewId: string) => {
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -114,6 +117,21 @@ export const usePostMemberReview = (crewId: string) => {
         isClosable: true,
       });
       queryClient.invalidateQueries([QUERY_KEYS.FOOD_PARTY.FOOD_PARTY_REVIEWEES, crewId]);
+    },
+  });
+};
+
+export const useUpdateFoodPartyStatus = (partyId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (status: string) => updateFoodPartyStatus(partyId, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEYS.FOOD_PARTY.FOOD_PARTY_DETAIL, partyId]);
+    },
+    onError: (error: unknown) => {
+      // To Do: 배포 전에 지우기 by 승준
+      console.error(error);
     },
   });
 };

--- a/src/hooks/query/useFoodParty.ts
+++ b/src/hooks/query/useFoodParty.ts
@@ -92,7 +92,7 @@ export const useCreateFoodParty = () => {
     mutationFn: createFoodParty,
     onSuccess: (data) => {
       const partyId = data.id;
-      router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL(partyId));
+      router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.INFORMATION(partyId));
       toast({
         title: '밥모임이 생성되었습니다!',
         description: '생성된 밥모임 정보를 확인하세요',

--- a/src/hooks/query/useFoodParty.ts
+++ b/src/hooks/query/useFoodParty.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import {
   createFoodParty,
+  createFoodPartyApplication,
   fetchFoodPartyDetail,
   fetchFoodPartyList,
   fetchFoodPartyReviewees,
@@ -41,12 +42,16 @@ export const useGetFoodPartyDetail = (partyId: string, userId?: number) => {
       memberUserId === userId && crewMemberRole === 'MEMBER'
   );
   const isFull = result.data?.currentMember === result.data?.capacity;
+  const leader = result.data?.members.find(
+    (member) => member.crewMemberRole === 'LEADER'
+  );
 
   return {
     ...result,
     isLeader,
     isMember,
     isFull,
+    leaderUserId: leader?.userId,
   };
 };
 
@@ -121,6 +126,24 @@ export const usePostMemberReview = (crewId: string) => {
         isClosable: true,
       });
       queryClient.invalidateQueries([QUERY_KEYS.FOOD_PARTY.FOOD_PARTY_REVIEWEES, crewId]);
+    },
+  });
+};
+
+export const useCreateFoodPartyApplication = (partyId: string, leaderUserId: number) => {
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: (content: string) =>
+      createFoodPartyApplication(partyId, content, leaderUserId),
+    onSuccess: () => {
+      toast({
+        title: '신청서가 제출되었습니다.',
+        position: 'top',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
     },
   });
 };

--- a/src/hooks/query/useFoodParty.ts
+++ b/src/hooks/query/useFoodParty.ts
@@ -10,7 +10,11 @@ import {
   postFoodPartyLeaderReview,
   postFoodPartyMemberReview,
 } from 'services/foodParty';
-import { FoodPartyLeaderReviewBody, FoodPartyMemberReviewBody } from 'types/foodParty';
+import {
+  FoodPartyLeaderReviewBody,
+  FoodPartyMemberReviewBody,
+  FoodPartyStatus,
+} from 'types/foodParty';
 import QUERY_KEYS from 'utils/constants/queryKeys';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
@@ -125,7 +129,7 @@ export const useUpdateFoodPartyStatus = (partyId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (status: string) => updateFoodPartyStatus(partyId, status),
+    mutationFn: (status: FoodPartyStatus) => updateFoodPartyStatus(partyId, status),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.FOOD_PARTY.FOOD_PARTY_DETAIL, partyId]);
     },

--- a/src/hooks/query/useFoodParty.ts
+++ b/src/hooks/query/useFoodParty.ts
@@ -51,7 +51,7 @@ export const useGetFoodPartyDetail = (partyId: string, userId?: number) => {
     isLeader,
     isMember,
     isFull,
-    leaderUserId: leader?.userId,
+    leaderUserId: leader?.userId || -1,
   };
 };
 

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -7,7 +7,10 @@ import FoodPartyDetailHeader from 'components/FoodParty/FoodPartyDetail/FoodPart
 import FoodPartyDetailSkeleton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailSkeleton';
 import FoodPartyMemberList from 'components/FoodParty/FoodPartyDetail/FoodPartyMemberList';
 import RestaurantBottomDrawer from 'components/Restaurant/RestaurantBottomDrawer';
-import { useGetFoodPartyDetail } from 'hooks/query/useFoodParty';
+import {
+  useGetFoodPartyDetail,
+  useUpdateFoodPartyStatus,
+} from 'hooks/query/useFoodParty';
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
 import { fetchFoodPartyDetail } from 'services/foodParty';
@@ -29,19 +32,31 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
     isFull,
     error,
   } = useGetFoodPartyDetail(partyId, userInformation?.id);
+  const { mutate: updateFoodPartyStatus } = useUpdateFoodPartyStatus(partyId);
   const { isOpen, onClose, onOpen } = useDisclosure();
 
   if (isLoading) return <FoodPartyDetailSkeleton />;
   if (error) return <div>{error.toString()}</div>;
 
-  // To Do: isLeader, isMember, isFull, status에 따라 다르게
-  // const router = useRouter();
-  // const handleClickButton = () => {
-  //  router.push
-  // }
   const handleClickFoodPartyDetailChangeStatusButton = (
     buttonText: FoodPartyDetailChangeStatusButtonText
-  ) => {};
+  ) => {
+    switch (buttonText) {
+      case '모집 완료할끼니?':
+        // alert
+        updateFoodPartyStatus('모집 완료');
+        return;
+      case '식사를 완료했끼니?':
+        // alert
+        updateFoodPartyStatus('식사 완료');
+        return;
+      case '참여할 끼니?':
+        // To Do: 신청서 드로어 띄우기 by 동우, 승준
+        return;
+      default:
+        return;
+    }
+  };
 
   return (
     <>

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -1,5 +1,4 @@
 import { Flex, useDisclosure } from '@chakra-ui/react';
-import { dehydrate, QueryClient } from '@tanstack/react-query';
 import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyApplicationDrawer from 'components/FoodParty/FoodPartyApplicationDrawer';
 import FoodPartyDetailChangeStatusButton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton';
@@ -16,10 +15,7 @@ import {
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { fetchFoodPartyDetail } from 'services/foodParty';
-import { fetchUser } from 'services/user';
 import { FoodPartyDetailChangeStatusButtonText } from 'types/foodParty';
-import QUERY_KEYS from 'utils/constants/queryKeys';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 // To Do: 404 처리 by 승준
@@ -133,23 +129,13 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
 
 export default FoodPartyDetail;
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { partyId } = context.query;
-
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery({
-    queryKey: [QUERY_KEYS.USER.MY_INFO],
-    queryFn: () => fetchUser(),
-  });
-  await queryClient.prefetchQuery({
-    queryKey: [QUERY_KEYS.FOOD_PARTY.FOOD_PARTY_DETAIL, partyId],
-    queryFn: () => fetchFoodPartyDetail(partyId as string),
-  });
 
   return {
     props: {
       partyId,
-      dehydratedState: dehydrate(queryClient),
     },
   };
 };

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -1,7 +1,8 @@
-import { Button, Flex, Text, useDisclosure } from '@chakra-ui/react';
+import { Flex, useDisclosure } from '@chakra-ui/react';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyDetailChangeStatusButton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton';
+import FoodPartyDetailContent from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailContent';
 import FoodPartyDetailHeader from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailHeader';
 import FoodPartyDetailSkeleton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailSkeleton';
 import FoodPartyMemberList from 'components/FoodParty/FoodPartyDetail/FoodPartyMemberList';
@@ -9,11 +10,9 @@ import RestaurantBottomDrawer from 'components/Restaurant/RestaurantBottomDrawer
 import { useGetFoodPartyDetail } from 'hooks/query/useFoodParty';
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
-import { AiOutlineCalendar, AiOutlineClockCircle, AiOutlineSearch } from 'react-icons/ai';
 import { fetchFoodPartyDetail } from 'services/foodParty';
 import { fetchUser } from 'services/user';
 import QUERY_KEYS from 'utils/constants/queryKeys';
-import { templatePromiseDate, templatePromiseTime } from 'utils/helpers/foodParty';
 
 // To Do: 404 처리 by 승준
 // partyId로 조회하는 페이지
@@ -34,9 +33,6 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
   if (isLoading) return <FoodPartyDetailSkeleton />;
   if (error) return <div>{error.toString()}</div>;
 
-  // To Do: Date 등 따로 컴포넌트를 빼자.
-  const [year, month, day, hour, minute] = foodPartyDetail!.promiseTime;
-
   // To Do: isLeader, isMember, isFull, status에 따라 다르게
   // const router = useRouter();
   // const handleClickButton = () => {
@@ -52,32 +48,16 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
           flexDirection='column'
           padding='1rem'
           gap='0.5rem'>
-          {/* 헤더 */}
           <FoodPartyDetailHeader
             status={foodPartyDetail.status}
             category={foodPartyDetail.category}
             foodPartyName={foodPartyDetail.name}
           />
-          {/* 데이터 & 가게 정보 */}
-          <Flex flexDirection='column' gap='0.5rem'>
-            <Flex alignItems='center' gap='0.5rem'>
-              <AiOutlineCalendar />
-              <Text>{templatePromiseDate(year, month, day)}</Text>
-            </Flex>
-            <Flex alignItems='center' gap='0.5rem'>
-              <AiOutlineClockCircle />
-              <Text>{templatePromiseTime(hour, minute)}</Text>
-            </Flex>
-            <Flex alignItems='center' gap='0.5rem'>
-              <AiOutlineSearch />
-              <Button onClick={onOpen} height='1.5rem'>
-                맛집 정보
-              </Button>
-            </Flex>
-          </Flex>
-          {/* 내용 */}
-          <Text margin='1rem 0'>{foodPartyDetail.content}</Text>
-          {/* 멤버 리스트 */}
+          <FoodPartyDetailContent
+            promiseTime={foodPartyDetail.promiseTime}
+            content={foodPartyDetail.content}
+            onClick={onOpen}
+          />
           <FoodPartyMemberList
             memberList={foodPartyDetail.members}
             capacity={foodPartyDetail.capacity}

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -13,6 +13,7 @@ import {
 } from 'hooks/query/useFoodParty';
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
 import { fetchFoodPartyDetail } from 'services/foodParty';
 import { fetchUser } from 'services/user';
 import { FoodPartyDetailChangeStatusButtonText } from 'types/foodParty';
@@ -34,6 +35,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
   } = useGetFoodPartyDetail(partyId, userInformation?.id);
   const { mutate: updateFoodPartyStatus } = useUpdateFoodPartyStatus(partyId);
   const { isOpen, onClose, onOpen } = useDisclosure();
+  const router = useRouter();
 
   if (isLoading) return <FoodPartyDetailSkeleton />;
   if (error) return <div>{error.toString()}</div>;
@@ -58,6 +60,11 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
     }
   };
 
+  const handleClickChatButton = () => {
+    // router;
+    console.log('chat button');
+  };
+
   return (
     <>
       {isSuccess ? (
@@ -78,6 +85,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
             onClick={onOpen}
           />
           <FoodPartyMemberList
+            onClickChatButton={isLeader || isMember ? handleClickChatButton : undefined}
             memberList={foodPartyDetail.members}
             capacity={foodPartyDetail.capacity}
           />

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -1,28 +1,18 @@
-import {
-  Button,
-  Divider,
-  Flex,
-  Heading,
-  Stack,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react';
+import { Button, Flex, Text, useDisclosure } from '@chakra-ui/react';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
-import Category from 'components/common/Category';
 import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyDetailChangeStatusButton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton';
+import FoodPartyDetailHeader from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailHeader';
 import FoodPartyDetailSkeleton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailSkeleton';
 import FoodPartyMemberList from 'components/FoodParty/FoodPartyDetail/FoodPartyMemberList';
 import RestaurantBottomDrawer from 'components/Restaurant/RestaurantBottomDrawer';
 import { useGetFoodPartyDetail } from 'hooks/query/useFoodParty';
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
-import Link from 'next/link';
 import { AiOutlineCalendar, AiOutlineClockCircle, AiOutlineSearch } from 'react-icons/ai';
 import { fetchFoodPartyDetail } from 'services/foodParty';
 import { fetchUser } from 'services/user';
 import QUERY_KEYS from 'utils/constants/queryKeys';
-import ROUTING_PATHS from 'utils/constants/routingPaths';
 import { templatePromiseDate, templatePromiseTime } from 'utils/helpers/foodParty';
 
 // To Do: 404 처리 by 승준
@@ -63,14 +53,11 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
           padding='1rem'
           gap='0.5rem'>
           {/* 헤더 */}
-          <Flex flexDirection='column' gap='0.5rem'>
-            <Stack direction='row'>
-              <Category>{foodPartyDetail.status}</Category>
-              <Category>{foodPartyDetail.category}</Category>
-            </Stack>
-            <Heading as='h1'>{foodPartyDetail.name}</Heading>
-            <Divider />
-          </Flex>
+          <FoodPartyDetailHeader
+            status={foodPartyDetail.status}
+            category={foodPartyDetail.category}
+            foodPartyName={foodPartyDetail.name}
+          />
           {/* 데이터 & 가게 정보 */}
           <Flex flexDirection='column' gap='0.5rem'>
             <Flex alignItems='center' gap='0.5rem'>

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -16,7 +16,7 @@ import {
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { createFoodPartyApplication, fetchFoodPartyDetail } from 'services/foodParty';
+import { fetchFoodPartyDetail } from 'services/foodParty';
 import { fetchUser } from 'services/user';
 import { FoodPartyDetailChangeStatusButtonText } from 'types/foodParty';
 import QUERY_KEYS from 'utils/constants/queryKeys';
@@ -27,6 +27,7 @@ import ROUTING_PATHS from 'utils/constants/routingPaths';
 // 조회가 안되면 404 처리
 const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
   const { data: userInformation } = useGetUser();
+  // To Do: 실시간 업데이트를 위한 refetch 필요 by 승준
   const {
     data: foodPartyDetail,
     isLoading,
@@ -52,7 +53,6 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
     onClose: onCloseApplicationDrawer,
     onOpen: onOpenApplicationDrawer,
   } = useDisclosure();
-
   const router = useRouter();
 
   if (isLoading) return <FoodPartyDetailSkeleton />;
@@ -63,15 +63,14 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
   ) => {
     switch (buttonText) {
       case '모집 완료할끼니?':
-        // alert
+        // To Do: alert 띄우기 by 승준
         updateFoodPartyStatus('모집 종료');
         return;
       case '식사를 완료했끼니?':
-        // alert
+        // To Do: alert 띄우기 by 승준
         updateFoodPartyStatus('식사 완료');
         return;
       case '참여할 끼니?':
-        // To Do: 신청서 드로어 띄우기 by 동우, 승준
         onOpenApplicationDrawer();
         return;
       default:
@@ -126,7 +125,6 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
           />
         </Flex>
       ) : (
-        // To Do: 스타일링 필요 by 승준
         <GoHomeWhenErrorInvoked />
       )}
     </>

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -103,6 +103,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
             capacity={foodPartyDetail.capacity}
           />
           <FoodPartyDetailStatusButton
+            applied={foodPartyDetail.proposalStatus}
             isLeader={isLeader}
             isMember={isMember}
             isFull={isFull}

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -12,6 +12,7 @@ import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
 import { fetchFoodPartyDetail } from 'services/foodParty';
 import { fetchUser } from 'services/user';
+import { FoodPartyDetailChangeStatusButtonText } from 'types/foodParty';
 import QUERY_KEYS from 'utils/constants/queryKeys';
 
 // To Do: 404 처리 by 승준
@@ -38,6 +39,9 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
   // const handleClickButton = () => {
   //  router.push
   // }
+  const handleClickFoodPartyDetailChangeStatusButton = (
+    buttonText: FoodPartyDetailChangeStatusButtonText
+  ) => {};
 
   return (
     <>
@@ -66,7 +70,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
             isLeader={isLeader}
             isMember={isMember}
             isFull={isFull}
-            // onClick={handleClickButton}
+            onClick={handleClickFoodPartyDetailChangeStatusButton}
             status={foodPartyDetail.status}
           />
           <RestaurantBottomDrawer

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -18,6 +18,7 @@ import { fetchFoodPartyDetail } from 'services/foodParty';
 import { fetchUser } from 'services/user';
 import { FoodPartyDetailChangeStatusButtonText } from 'types/foodParty';
 import QUERY_KEYS from 'utils/constants/queryKeys';
+import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 // To Do: 404 처리 by 승준
 // partyId로 조회하는 페이지
@@ -46,7 +47,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
     switch (buttonText) {
       case '모집 완료할끼니?':
         // alert
-        updateFoodPartyStatus('모집 완료');
+        updateFoodPartyStatus('모집 종료');
         return;
       case '식사를 완료했끼니?':
         // alert
@@ -61,8 +62,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
   };
 
   const handleClickChatButton = () => {
-    // router;
-    console.log('chat button');
+    router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.CHAT(partyId));
   };
 
   return (
@@ -128,7 +128,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {
       partyId,
-      storeId: '1',
       dehydratedState: dehydrate(queryClient),
     },
   };

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -1,10 +1,10 @@
 import { Flex, useDisclosure } from '@chakra-ui/react';
 import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyApplicationDrawer from 'components/FoodParty/FoodPartyApplicationDrawer';
-import FoodPartyDetailChangeStatusButton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton';
 import FoodPartyDetailContent from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailContent';
 import FoodPartyDetailHeader from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailHeader';
 import FoodPartyDetailSkeleton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailSkeleton';
+import FoodPartyDetailStatusButton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailStatusButton';
 import FoodPartyMemberList from 'components/FoodParty/FoodPartyDetail/FoodPartyMemberList';
 import RestaurantBottomDrawer from 'components/Restaurant/RestaurantBottomDrawer';
 import {
@@ -15,7 +15,7 @@ import {
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { FoodPartyDetailChangeStatusButtonText } from 'types/foodParty';
+import { FoodPartyDetailStatusButtonText } from 'types/foodParty';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 // To Do: 404 처리 by 승준
@@ -54,8 +54,8 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
   if (isLoading) return <FoodPartyDetailSkeleton />;
   if (error) return <div>{error.toString()}</div>;
 
-  const handleClickFoodPartyDetailChangeStatusButton = (
-    buttonText: FoodPartyDetailChangeStatusButtonText
+  const handleClickFoodPartyDetailStatusButton = (
+    buttonText: FoodPartyDetailStatusButtonText
   ) => {
     switch (buttonText) {
       case '모집 완료할끼니?':
@@ -102,11 +102,11 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
             memberList={foodPartyDetail.members}
             capacity={foodPartyDetail.capacity}
           />
-          <FoodPartyDetailChangeStatusButton
+          <FoodPartyDetailStatusButton
             isLeader={isLeader}
             isMember={isMember}
             isFull={isFull}
-            onClick={handleClickFoodPartyDetailChangeStatusButton}
+            onClick={handleClickFoodPartyDetailStatusButton}
             status={foodPartyDetail.crewStatus}
           />
           <RestaurantBottomDrawer

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -88,7 +88,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
           padding='1rem'
           gap='0.5rem'>
           <FoodPartyDetailHeader
-            status={foodPartyDetail.status}
+            status={foodPartyDetail.crewStatus}
             category={foodPartyDetail.category}
             foodPartyName={foodPartyDetail.name}
           />
@@ -107,7 +107,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
             isMember={isMember}
             isFull={isFull}
             onClick={handleClickFoodPartyDetailChangeStatusButton}
-            status={foodPartyDetail.status}
+            status={foodPartyDetail.crewStatus}
           />
           <RestaurantBottomDrawer
             isOpen={isOpenRestaurantBottomDrawer}

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -9,6 +9,7 @@ import {
 } from '@chakra-ui/react';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Category from 'components/common/Category';
+import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyDetailChangeStatusButton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailChangeStatusButton';
 import FoodPartyDetailSkeleton from 'components/FoodParty/FoodPartyDetail/FoodPartyDetailSkeleton';
 import FoodPartyMemberList from 'components/FoodParty/FoodPartyDetail/FoodPartyMemberList';
@@ -16,10 +17,12 @@ import RestaurantBottomDrawer from 'components/Restaurant/RestaurantBottomDrawer
 import { useGetFoodPartyDetail } from 'hooks/query/useFoodParty';
 import { useGetUser } from 'hooks/query/useUser';
 import { GetServerSideProps } from 'next';
+import Link from 'next/link';
 import { AiOutlineCalendar, AiOutlineClockCircle, AiOutlineSearch } from 'react-icons/ai';
 import { fetchFoodPartyDetail } from 'services/foodParty';
 import { fetchUser } from 'services/user';
 import QUERY_KEYS from 'utils/constants/queryKeys';
+import ROUTING_PATHS from 'utils/constants/routingPaths';
 import { templatePromiseDate, templatePromiseTime } from 'utils/helpers/foodParty';
 
 // To Do: 404 처리 by 승준
@@ -107,7 +110,7 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
         </Flex>
       ) : (
         // To Do: 스타일링 필요 by 승준
-        <Text>서버에 문제가 발생했습니다.</Text>
+        <GoHomeWhenErrorInvoked />
       )}
     </>
   );

--- a/src/pages/food-party/detail/chat/[roomId].tsx
+++ b/src/pages/food-party/detail/chat/[roomId].tsx
@@ -1,3 +1,37 @@
-const FoodPartyDetailChat = () => {};
+import { CompatClient, Stomp } from '@stomp/stompjs';
+import { axiosAuthApi } from 'apis/axios';
+import { useRouter } from 'next/router';
+import { useEffect, useRef, useState } from 'react';
+import SockJS from 'sockjs-client';
+
+const FoodPartyDetailChat = () => {
+  const router = useRouter();
+  const client = useRef<CompatClient>();
+  const [messageList, setMessageList] = useState([]);
+
+  useEffect(() => {
+    const { roomId } = router.query;
+    if (!roomId) return;
+
+    client.current = Stomp.over(
+      () => new SockJS(`${process.env.NEXT_PUBLIC_API_END_POINT}/ws`)
+    );
+
+    const axiosAuthApiAuthorization =
+      axiosAuthApi.defaults.headers.common['Authorization'];
+    client.current.connect(
+      {
+        Authorization: axiosAuthApiAuthorization,
+      },
+      () => {
+        client.current?.subscribe(`/topic/public/${roomId as string}`, (payload) => {
+          // const message = JSON.parse(payload.body);
+        });
+      }
+    );
+  }, []);
+
+  return <div></div>;
+};
 
 export default FoodPartyDetailChat;

--- a/src/pages/food-party/detail/chat/[roomId].tsx
+++ b/src/pages/food-party/detail/chat/[roomId].tsx
@@ -1,0 +1,3 @@
+const FoodPartyDetailChat = () => {};
+
+export default FoodPartyDetailChat;

--- a/src/pages/food-party/list/my.tsx
+++ b/src/pages/food-party/list/my.tsx
@@ -1,4 +1,5 @@
 import { Flex, Heading } from '@chakra-ui/react';
+import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyList from 'components/FoodParty/FoodPartyList';
 import FoodPartyListSkeleton from 'components/FoodParty/FoodPartyListSkeleton';
 import { useGetMyFoodPartyList } from 'hooks/query/useFoodParty';
@@ -7,7 +8,7 @@ import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 const MyFoodPartyList = () => {
   const router = useRouter();
-  // To Do: 현재 인원 실시간 업데이트를 위한 refetch 필요 by 승준
+  // To Do: 실시간 업데이트를 위한 refetch 필요 by 승준
   const { data: myFoodPartyList, isLoading, error, isSuccess } = useGetMyFoodPartyList();
   const handleClickViewFoodPartyButton = (partyId: number) => {
     router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.INFORMATION(partyId));
@@ -20,14 +21,20 @@ const MyFoodPartyList = () => {
   if (error) return <div>{error.toString()}</div>;
 
   return (
-    <Flex flexDirection='column' padding='1rem'>
-      <Heading paddingBottom='1rem'>너님의 밥모임 목록</Heading>
-      <FoodPartyList
-        foodPartyList={isSuccess ? myFoodPartyList : []}
-        onClickViewButton={handleClickViewFoodPartyButton}
-        onClickReviewButton={handleClickReviewFoodPartyButton}
-      />
-    </Flex>
+    <>
+      {isSuccess ? (
+        <Flex flexDirection='column' padding='1rem'>
+          <Heading paddingBottom='1rem'>나의 밥모임 목록</Heading>
+          <FoodPartyList
+            foodPartyList={myFoodPartyList}
+            onClickViewButton={handleClickViewFoodPartyButton}
+            onClickReviewButton={handleClickReviewFoodPartyButton}
+          />
+        </Flex>
+      ) : (
+        <GoHomeWhenErrorInvoked />
+      )}
+    </>
   );
 };
 

--- a/src/pages/food-party/list/my.tsx
+++ b/src/pages/food-party/list/my.tsx
@@ -9,8 +9,11 @@ const MyFoodPartyList = () => {
   const router = useRouter();
   // To Do: 현재 인원 실시간 업데이트를 위한 refetch 필요 by 승준
   const { data: myFoodPartyList, isLoading, error, isSuccess } = useGetMyFoodPartyList();
-  const handleClickFoodPartyItem = (partyId: number) => {
+  const handleClickViewFoodPartyButton = (partyId: number) => {
     router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL(partyId));
+  };
+  const handleClickReviewFoodPartyButton = (partyId: number) => {
+    router.push(ROUTING_PATHS.FOOD_PARTY.REVIEW(partyId));
   };
 
   if (isLoading) return <FoodPartyListSkeleton foodPartyCount={2} />;
@@ -21,7 +24,8 @@ const MyFoodPartyList = () => {
       <Heading paddingBottom='1rem'>너님의 밥모임 목록</Heading>
       <FoodPartyList
         foodPartyList={isSuccess ? myFoodPartyList : []}
-        onClick={handleClickFoodPartyItem}
+        onClickViewButton={handleClickViewFoodPartyButton}
+        onClickReviewButton={handleClickReviewFoodPartyButton}
       />
     </Flex>
   );

--- a/src/pages/food-party/list/my.tsx
+++ b/src/pages/food-party/list/my.tsx
@@ -10,7 +10,7 @@ const MyFoodPartyList = () => {
   // To Do: 현재 인원 실시간 업데이트를 위한 refetch 필요 by 승준
   const { data: myFoodPartyList, isLoading, error, isSuccess } = useGetMyFoodPartyList();
   const handleClickViewFoodPartyButton = (partyId: number) => {
-    router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL(partyId));
+    router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.INFORMATION(partyId));
   };
   const handleClickReviewFoodPartyButton = (partyId: number) => {
     router.push(ROUTING_PATHS.FOOD_PARTY.REVIEW(partyId));

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -25,7 +25,7 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
   } = useGetSearchedFoodPartyList(placeId);
   const router = useRouter();
   const handleClickFoodPartyItem = (partyId: number) => {
-    router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL(partyId));
+    router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.INFORMATION(partyId));
   };
 
   if (isLoading) return <FoodPartyListSkeleton foodPartyCount={2} />;
@@ -38,7 +38,7 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
           <Heading paddingBottom='1rem'>{name}의 밥모임</Heading>
           <FoodPartyList
             foodPartyList={foodPartyList}
-            onClick={handleClickFoodPartyItem}
+            onClickViewButton={handleClickFoodPartyItem}
           />
         </Flex>
       )}

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -2,9 +2,12 @@ import { Flex, Heading } from '@chakra-ui/react';
 import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyList from 'components/FoodParty/FoodPartyList';
 import FoodPartyListSkeleton from 'components/FoodParty/FoodPartyListSkeleton';
+import useRandomRestaurantContext from 'contexts/kakaoMap/randomRestaurant';
 import { useGetSearchedFoodPartyList } from 'hooks/query/useFoodParty';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
+import { useSetRecoilState } from 'recoil';
+import { selectedRestaurantState } from 'stores/Restaurant';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 type SearchedFoodPartyListQuery = {
@@ -21,9 +24,36 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
     error,
     isSuccess,
   } = useGetSearchedFoodPartyList(placeId);
+  const { randomRestaurant } = useRandomRestaurantContext();
+  const setSelectedRestaurant = useSetRecoilState(selectedRestaurantState);
   const router = useRouter();
   const handleClickFoodPartyItem = (partyId: number) => {
     router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.INFORMATION(partyId));
+  };
+  const handleClickCreateFoodPartyButton = () => {
+    const {
+      placeId,
+      placeName,
+      categories,
+      roadAddressName,
+      photoUrls,
+      kakaoPlaceUrl,
+      phoneNumber,
+      longitude,
+      latitude,
+    } = randomRestaurant;
+    setSelectedRestaurant({
+      placeId: String(placeId),
+      placeName,
+      categories,
+      roadAddressName,
+      photoUrls: photoUrls?.split(',') || [],
+      kakaoPlaceUrl,
+      phoneNumber,
+      longitude,
+      latitude,
+    });
+    router.push(ROUTING_PATHS.FOOD_PARTY.CREATE);
   };
 
   if (isLoading) return <FoodPartyListSkeleton foodPartyCount={2} />;
@@ -37,6 +67,7 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
           <FoodPartyList
             foodPartyList={foodPartyList}
             onClickViewButton={handleClickFoodPartyItem}
+            onClickCreateFoodPartyButton={handleClickCreateFoodPartyButton}
           />
         </Flex>
       ) : (

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router';
 import { useSetRecoilState } from 'recoil';
 import { selectedRestaurantState } from 'stores/Restaurant';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
+import { getPhotoUrlsArray } from 'utils/helpers/foodParty';
 
 type SearchedFoodPartyListQuery = {
   placeId: string;
@@ -47,7 +48,7 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
       placeName,
       categories,
       roadAddressName,
-      photoUrls: photoUrls?.split(',') || [],
+      photoUrls: getPhotoUrlsArray(photoUrls || ''),
       kakaoPlaceUrl,
       phoneNumber,
       longitude,

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -1,13 +1,10 @@
 import { Flex, Heading } from '@chakra-ui/react';
-import { QueryClient } from '@tanstack/react-query';
 import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyList from 'components/FoodParty/FoodPartyList';
 import FoodPartyListSkeleton from 'components/FoodParty/FoodPartyListSkeleton';
 import { useGetSearchedFoodPartyList } from 'hooks/query/useFoodParty';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { fetchFoodPartyList } from 'services/foodParty';
-import QUERY_KEYS from 'utils/constants/queryKeys';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 type SearchedFoodPartyListQuery = {
@@ -51,13 +48,9 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
 
 export default SearchedFoodPartyList;
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { placeId, name } = context.query;
-  const queryClient = new QueryClient();
-  await queryClient.prefetchQuery({
-    queryKey: [QUERY_KEYS.FOOD_PARTY.SEARCHED_FOOD_PARTY_LIST, placeId],
-    queryFn: () => fetchFoodPartyList(placeId as string),
-  });
 
   return {
     props: {

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -1,5 +1,6 @@
 import { Flex, Heading } from '@chakra-ui/react';
 import { QueryClient } from '@tanstack/react-query';
+import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import FoodPartyList from 'components/FoodParty/FoodPartyList';
 import FoodPartyListSkeleton from 'components/FoodParty/FoodPartyListSkeleton';
 import { useGetSearchedFoodPartyList } from 'hooks/query/useFoodParty';
@@ -33,7 +34,7 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
 
   return (
     <>
-      {isSuccess && (
+      {isSuccess ? (
         <Flex flexDirection='column' padding='1rem'>
           <Heading paddingBottom='1rem'>{name}의 밥모임</Heading>
           <FoodPartyList
@@ -41,6 +42,8 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
             onClickViewButton={handleClickFoodPartyItem}
           />
         </Flex>
+      ) : (
+        <GoHomeWhenErrorInvoked />
       )}
     </>
   );

--- a/src/services/foodParty.ts
+++ b/src/services/foodParty.ts
@@ -7,6 +7,7 @@ import {
   FoodPartyLeaderReviewBody,
   FoodPartyMemberReviewBody,
   FoodPartyRevieweeType,
+  FoodPartyStatus,
 } from 'types/foodParty';
 
 type responseBodyType = {
@@ -109,7 +110,7 @@ export const postFoodPartyMemberReview = async (
   return response;
 };
 
-export const updateFoodPartyStatus = async (partyId: string, status: string) => {
+export const updateFoodPartyStatus = async (partyId: string, status: FoodPartyStatus) => {
   await axiosAuthApi.patch('/api/v1/crews', {
     crewId: partyId,
     status,

--- a/src/services/foodParty.ts
+++ b/src/services/foodParty.ts
@@ -108,3 +108,10 @@ export const postFoodPartyMemberReview = async (
   );
   return response;
 };
+
+export const updateFoodPartyStatus = async (partyId: string, status: string) => {
+  await axiosAuthApi.patch('/api/v1/crews', {
+    crewId: partyId,
+    status,
+  });
+};

--- a/src/services/foodParty.ts
+++ b/src/services/foodParty.ts
@@ -111,5 +111,7 @@ export const postFoodPartyMemberReview = async (
 };
 
 export const updateFoodPartyStatus = async (partyId: string, status: FoodPartyStatus) => {
-  await axiosAuthApi.patch(`/api/v1/crews/${partyId}/close`);
+  await axiosAuthApi.patch(`/api/v1/crews/${partyId}`, {
+    crewStatus: status,
+  });
 };

--- a/src/services/foodParty.ts
+++ b/src/services/foodParty.ts
@@ -111,8 +111,5 @@ export const postFoodPartyMemberReview = async (
 };
 
 export const updateFoodPartyStatus = async (partyId: string, status: FoodPartyStatus) => {
-  await axiosAuthApi.patch('/api/v1/crews', {
-    crewId: partyId,
-    status,
-  });
+  await axiosAuthApi.patch(`/api/v1/crews/${partyId}/close`);
 };

--- a/src/services/foodParty.ts
+++ b/src/services/foodParty.ts
@@ -110,6 +110,21 @@ export const postFoodPartyMemberReview = async (
   return response;
 };
 
+export const createFoodPartyApplication = async (
+  partyId: string,
+  content: string,
+  leaderUserId: number
+): Promise<{ id: number }> => {
+  const response = await axiosAuthApi.post<{ id: number }>(
+    `/api/v1/crews/${partyId}/proposals`,
+    {
+      leaderId: leaderUserId,
+      content,
+    }
+  );
+  return response.data;
+};
+
 export const updateFoodPartyStatus = async (partyId: string, status: FoodPartyStatus) => {
   await axiosAuthApi.patch(`/api/v1/crews/${partyId}`, {
     crewStatus: status,

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -3,7 +3,7 @@ import { Restaurant } from './restaurant';
 
 type CrewMemberRole = 'LEADER' | 'MEMBER' | 'BLOCKED';
 
-export type FoodPartyStatus = '모집중' | '모집 완료' | '식사 완료';
+export type FoodPartyStatus = '모집 중' | '모집 완료' | '식사 완료';
 
 export type FoodPartyDetailChangeStatusButtonText =
   | '모집 완료할끼니?'

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -6,9 +6,8 @@ type CrewMemberRole = 'LEADER' | 'MEMBER' | 'BLOCKED';
 export type FoodPartyStatus = '모집중' | '모집 완료' | '식사 완료';
 
 export type FoodPartyDetailChangeStatusButtonText =
-  | '모집 완료했끼니?'
+  | '모집 완료할끼니?'
   | '식사를 완료했끼니?'
-  | '리뷰 작성하러 갈끼니?'
   | '참여할 끼니?'
   | '모집이 완료되버렸끼니!'
   | '인원이 꽉 차버렸끼니!'

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -26,7 +26,7 @@ export type FoodParty = {
   currentMember: number;
   capacity: number;
   promiseTime: number[];
-  status: FoodPartyStatus;
+  crewStatus: FoodPartyStatus;
   content: string;
   category: string;
   members: Member[];

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -3,7 +3,7 @@ import { Restaurant } from './restaurant';
 
 type CrewMemberRole = 'LEADER' | 'MEMBER' | 'BLOCKED';
 
-export type ProposalStatus = '미신청' | '대기 중';
+export type ProposalStatus = '미신청' | '대기 중' | '승인' | '거절';
 
 export type FoodPartyStatus = '모집 중' | '모집 종료' | '식사 완료';
 
@@ -14,6 +14,7 @@ export type FoodPartyDetailStatusButtonText =
   | '모집이 완료되버렸끼니!'
   | '인원이 꽉 차버렸끼니!'
   | '수락 대기 중'
+  | '거절 당했어요...'
   | '';
 
 export type Member = {

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -5,7 +5,7 @@ type CrewMemberRole = 'LEADER' | 'MEMBER' | 'BLOCKED';
 
 export type FoodPartyStatus = '모집 중' | '모집 종료' | '식사 완료';
 
-export type FoodPartyDetailChangeStatusButtonText =
+export type FoodPartyDetailStatusButtonText =
   | '모집 완료할끼니?'
   | '식사를 완료했끼니?'
   | '참여할 끼니?'

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -3,7 +3,15 @@ import { Restaurant } from './restaurant';
 
 type CrewMemberRole = 'LEADER' | 'MEMBER' | 'BLOCKED';
 
-export type FoodPartyStatus = '모집 중' | '모집 완료' | '식사 완료';
+export type FoodPartyStatus = '모집중' | '모집 완료' | '식사 완료';
+
+export type FoodPartyDetailChangeStatusButtonText =
+  | '모집 완료했끼니?'
+  | '식사를 완료했끼니?'
+  | '리뷰 작성하러 갈끼니?'
+  | '참여할 끼니?'
+  | '모집이 완료되버렸끼니!'
+  | '';
 
 export type Member = {
   userId: number;

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -3,7 +3,7 @@ import { Restaurant } from './restaurant';
 
 type CrewMemberRole = 'LEADER' | 'MEMBER' | 'BLOCKED';
 
-export type FoodPartyStatus = '모집 중' | '모집 완료' | '식사 완료';
+export type FoodPartyStatus = '모집 중' | '모집 종료' | '식사 완료';
 
 export type FoodPartyDetailChangeStatusButtonText =
   | '모집 완료할끼니?'

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -11,6 +11,7 @@ export type FoodPartyDetailChangeStatusButtonText =
   | '리뷰 작성하러 갈끼니?'
   | '참여할 끼니?'
   | '모집이 완료되버렸끼니!'
+  | '인원이 꽉 차버렸끼니!'
   | '';
 
 export type Member = {

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -3,6 +3,8 @@ import { Restaurant } from './restaurant';
 
 type CrewMemberRole = 'LEADER' | 'MEMBER' | 'BLOCKED';
 
+export type ProposalStatus = '미신청' | '대기 중';
+
 export type FoodPartyStatus = '모집 중' | '모집 종료' | '식사 완료';
 
 export type FoodPartyDetailStatusButtonText =
@@ -11,6 +13,7 @@ export type FoodPartyDetailStatusButtonText =
   | '참여할 끼니?'
   | '모집이 완료되버렸끼니!'
   | '인원이 꽉 차버렸끼니!'
+  | '수락 대기 중'
   | '';
 
 export type Member = {
@@ -30,6 +33,7 @@ export type FoodParty = {
   content: string;
   category: string;
   members: Member[];
+  proposalStatus: ProposalStatus;
 };
 
 export type FoodPartyDetail = { response: Restaurant } & FoodParty;

--- a/src/utils/constants/routingPaths.ts
+++ b/src/utils/constants/routingPaths.ts
@@ -7,7 +7,10 @@ const ROUTING_PATHS = {
       RESTAURANT: (placeId: string | number, placeName: string) =>
         `/food-party/list/restaurant/${placeId}?name=${placeName}`,
     },
-    DETAIL: (partyId: string | number) => `/food-party/detail/${partyId}`,
+    DETAIL: {
+      INFORMATION: (partyId: string | number) => `/food-party/detail/${partyId}`,
+      CHAT: (roomId: string | number) => `/food-party/detail/chat/${roomId}`,
+    },
     REVIEW: (partyId: string | number) => `/food-party/review/${partyId}`,
   },
 };

--- a/src/utils/constants/routingPaths.ts
+++ b/src/utils/constants/routingPaths.ts
@@ -8,6 +8,7 @@ const ROUTING_PATHS = {
         `/food-party/list/restaurant/${placeId}?name=${placeName}`,
     },
     DETAIL: (partyId: string | number) => `/food-party/detail/${partyId}`,
+    REVIEW: (partyId: string | number) => `/food-party/review/${partyId}`,
   },
 };
 

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -54,7 +54,7 @@ export const checkButtonTextIsDisabled = (
 const LeaderText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {
-  모집중: '모집 완료할끼니?',
+  '모집 중': '모집 완료할끼니?',
   '모집 완료': '식사를 완료했끼니?',
   '식사 완료': '',
 };
@@ -62,7 +62,7 @@ const LeaderText: {
 const MemberText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {
-  모집중: '',
+  '모집 중': '',
   '모집 완료': '',
   '식사 완료': '',
 };
@@ -70,7 +70,7 @@ const MemberText: {
 const NotMemberText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {
-  모집중: '참여할 끼니?',
+  '모집 중': '참여할 끼니?',
   '모집 완료': '모집이 완료되버렸끼니!',
   '식사 완료': '',
 };

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -54,9 +54,9 @@ export const checkButtonTextIsDisabled = (
 const LeaderText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {
-  모집중: '모집 완료했끼니?',
+  모집중: '모집 완료할끼니?',
   '모집 완료': '식사를 완료했끼니?',
-  '식사 완료': '리뷰 작성하러 갈끼니?',
+  '식사 완료': '',
 };
 
 const MemberText: {
@@ -64,7 +64,7 @@ const MemberText: {
 } = {
   모집중: '',
   '모집 완료': '',
-  '식사 완료': '리뷰 작성하러 갈끼니?',
+  '식사 완료': '',
 };
 
 const NotMemberText: {

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -50,7 +50,6 @@ export const checkButtonTextIsDisabled = (
   );
 };
 
-// getFoodPartyDetailChangeStatusButtonText, checkButtonTextIsDisabled에 사용되는 상수들
 const LeaderText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -14,6 +14,8 @@ export const getPhotoUrlsString = (photoUrls: string[]) => {
 };
 
 export const getPhotoUrlsArray = (photoUrls: string) => {
+  if (!photoUrls) return [];
+
   return photoUrls.split(',');
 };
 

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -1,4 +1,8 @@
-import { FoodPartyDetailStatusButtonText, FoodPartyStatus } from 'types/foodParty';
+import {
+  FoodPartyDetailStatusButtonText,
+  FoodPartyStatus,
+  ProposalStatus,
+} from 'types/foodParty';
 import { DocumentsType } from 'types/kakaoSearch';
 
 export const getPhotoUrlsStringFromDocuments = (documents: DocumentsType[]) => {
@@ -26,6 +30,7 @@ export const templatePromiseTime = (hour: number, minute: number) => {
 };
 
 export const getFoodPartyDetailStatusButtonText = (
+  applied: ProposalStatus,
   isLeader: boolean,
   isMember: boolean,
   isFull: boolean,
@@ -38,6 +43,7 @@ export const getFoodPartyDetailStatusButtonText = (
   if (isMember) return MemberText[status];
 
   // 참여하지 않은 경우
+  if (applied === '대기 중') return '수락 대기 중';
   if (isFull) return '인원이 꽉 차버렸끼니!';
   return NotMemberText[status];
 };
@@ -46,7 +52,9 @@ export const checkButtonTextIsDisabled = (
   buttonText: FoodPartyDetailStatusButtonText
 ) => {
   return (
-    buttonText === '인원이 꽉 차버렸끼니!' || buttonText === '모집이 완료되버렸끼니!'
+    buttonText === '인원이 꽉 차버렸끼니!' ||
+    buttonText === '모집이 완료되버렸끼니!' ||
+    buttonText === '수락 대기 중'
   );
 };
 

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -55,7 +55,7 @@ const LeaderText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {
   '모집 중': '모집 완료할끼니?',
-  '모집 완료': '식사를 완료했끼니?',
+  '모집 종료': '식사를 완료했끼니?',
   '식사 완료': '',
 };
 
@@ -63,7 +63,7 @@ const MemberText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {
   '모집 중': '',
-  '모집 완료': '',
+  '모집 종료': '',
   '식사 완료': '',
 };
 
@@ -71,6 +71,6 @@ const NotMemberText: {
   [key: string]: FoodPartyDetailChangeStatusButtonText;
 } = {
   '모집 중': '참여할 끼니?',
-  '모집 완료': '모집이 완료되버렸끼니!',
+  '모집 종료': '모집이 완료되버렸끼니!',
   '식사 완료': '',
 };

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -43,6 +43,7 @@ export const getFoodPartyDetailStatusButtonText = (
   if (isMember) return MemberText[status];
 
   // 참여하지 않은 경우
+  if (applied === '거절') return '거절 당했어요...';
   if (applied === '대기 중') return '수락 대기 중';
   if (isFull) return '인원이 꽉 차버렸끼니!';
   return NotMemberText[status];
@@ -54,7 +55,8 @@ export const checkButtonTextIsDisabled = (
   return (
     buttonText === '인원이 꽉 차버렸끼니!' ||
     buttonText === '모집이 완료되버렸끼니!' ||
-    buttonText === '수락 대기 중'
+    buttonText === '수락 대기 중' ||
+    buttonText === '거절 당했어요...'
   );
 };
 

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -1,3 +1,4 @@
+import { FoodPartyDetailChangeStatusButtonText, FoodPartyStatus } from 'types/foodParty';
 import { DocumentsType } from 'types/kakaoSearch';
 
 export const getPhotoUrlsStringFromDocuments = (documents: DocumentsType[]) => {
@@ -22,4 +23,54 @@ export const templatePromiseDate = (year: number, month: number, day: number) =>
 
 export const templatePromiseTime = (hour: number, minute: number) => {
   return `${hour}:${String(minute).padStart(2, '0')}`;
+};
+
+export const getFoodPartyDetailChangeStatusButtonText = (
+  isLeader: boolean,
+  isMember: boolean,
+  isFull: boolean,
+  status: FoodPartyStatus
+): FoodPartyDetailChangeStatusButtonText => {
+  // 방장인 경우
+  if (isLeader) return LeaderText[status];
+
+  // 멤버인 경우
+  if (isMember) return MemberText[status];
+
+  // 참여하지 않은 경우
+  if (isFull) return '인원이 꽉 차버렸끼니!';
+  return NotMemberText[status];
+};
+
+export const checkButtonTextIsDisabled = (
+  buttonText: FoodPartyDetailChangeStatusButtonText
+) => {
+  return (
+    buttonText === '인원이 꽉 차버렸끼니!' || buttonText === '모집이 완료되버렸끼니!'
+  );
+};
+
+// getFoodPartyDetailChangeStatusButtonText, checkButtonTextIsDisabled에 사용되는 상수들
+const LeaderText: {
+  [key: string]: FoodPartyDetailChangeStatusButtonText;
+} = {
+  모집중: '모집 완료했끼니?',
+  '모집 완료': '식사를 완료했끼니?',
+  '식사 완료': '리뷰 작성하러 갈끼니?',
+};
+
+const MemberText: {
+  [key: string]: FoodPartyDetailChangeStatusButtonText;
+} = {
+  모집중: '',
+  '모집 완료': '',
+  '식사 완료': '리뷰 작성하러 갈끼니?',
+};
+
+const NotMemberText: {
+  [key: string]: FoodPartyDetailChangeStatusButtonText;
+} = {
+  모집중: '참여할 끼니?',
+  '모집 완료': '모집이 완료되버렸끼니!',
+  '식사 완료': '',
 };

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -1,4 +1,4 @@
-import { FoodPartyDetailChangeStatusButtonText, FoodPartyStatus } from 'types/foodParty';
+import { FoodPartyDetailStatusButtonText, FoodPartyStatus } from 'types/foodParty';
 import { DocumentsType } from 'types/kakaoSearch';
 
 export const getPhotoUrlsStringFromDocuments = (documents: DocumentsType[]) => {
@@ -25,12 +25,12 @@ export const templatePromiseTime = (hour: number, minute: number) => {
   return `${hour}:${String(minute).padStart(2, '0')}`;
 };
 
-export const getFoodPartyDetailChangeStatusButtonText = (
+export const getFoodPartyDetailStatusButtonText = (
   isLeader: boolean,
   isMember: boolean,
   isFull: boolean,
   status: FoodPartyStatus
-): FoodPartyDetailChangeStatusButtonText => {
+): FoodPartyDetailStatusButtonText => {
   // 방장인 경우
   if (isLeader) return LeaderText[status];
 
@@ -43,7 +43,7 @@ export const getFoodPartyDetailChangeStatusButtonText = (
 };
 
 export const checkButtonTextIsDisabled = (
-  buttonText: FoodPartyDetailChangeStatusButtonText
+  buttonText: FoodPartyDetailStatusButtonText
 ) => {
   return (
     buttonText === '인원이 꽉 차버렸끼니!' || buttonText === '모집이 완료되버렸끼니!'
@@ -51,7 +51,7 @@ export const checkButtonTextIsDisabled = (
 };
 
 const LeaderText: {
-  [key: string]: FoodPartyDetailChangeStatusButtonText;
+  [key: string]: FoodPartyDetailStatusButtonText;
 } = {
   '모집 중': '모집 완료할끼니?',
   '모집 종료': '식사를 완료했끼니?',
@@ -59,7 +59,7 @@ const LeaderText: {
 };
 
 const MemberText: {
-  [key: string]: FoodPartyDetailChangeStatusButtonText;
+  [key: string]: FoodPartyDetailStatusButtonText;
 } = {
   '모집 중': '',
   '모집 종료': '',
@@ -67,7 +67,7 @@ const MemberText: {
 };
 
 const NotMemberText: {
-  [key: string]: FoodPartyDetailChangeStatusButtonText;
+  [key: string]: FoodPartyDetailStatusButtonText;
 } = {
   '모집 중': '참여할 끼니?',
   '모집 종료': '모집이 완료되버렸끼니!',


### PR DESCRIPTION
## 💡 Linked Issues

- #61
- #85 
- close #124 
- close #130
- close #134 

## 📖 구현 내용

- 밥모임 신청 로직
- 밥모임 상태 변경 로직 구현
- 서버 에러 발생 시 보여줄 컴포넌트 생성
- 밥모임 상세 페이지를 헤더, 내용, 버튼 등에 따라 컴포넌트로 분류
- 랜덤 맛집의 밥모임이 없을 때 생성 가능하도록 로직 구현
- 신청서 작성 이후 참여할 끼니 버튼이 안 보이도록 구현

## 🖼 구현 이미지
- 밥모임 신청 로직
![apply](https://user-images.githubusercontent.com/93233930/224336499-fc0bc09a-ca29-4340-8e8e-57a63037e40f.gif)

- 밥모임 상태 변경 로직 구현
![status](https://user-images.githubusercontent.com/93233930/224336563-1a610980-0f96-40a8-a3a6-2f1ad4594b9d.gif)

- 서버 에러 발생 시 보여줄 컴포넌트 생성
![error](https://user-images.githubusercontent.com/93233930/224336616-fc1f6897-d3a3-4e9f-8ea0-2c6abbf32e1a.gif)

- 랜덤 맛집의 밥모임이 없을 때 생성 가능하도록 로직 구현(용량이 커서 생성되는 것 까지는 못 찍었는데 생성 제대로 됩니다!)
![create](https://user-images.githubusercontent.com/93233930/224468492-f16f9a8a-9974-44f9-9537-ddcc25488603.gif)

- 신청서 작성 이후 참여
![apply-2](https://user-images.githubusercontent.com/93233930/224474818-7939f7b1-8641-4a50-b8d1-36738ec91cb3.gif)
할 끼니 버튼이 안 보이도록 구현

## ✅ PR 포인트 & 궁금한 점
- 밥모임 상태 변경은 현재 에러가 있어 건우님께서 변경 중이시고, 신청서 작성이 중복되는 것은 은비님이 변경 완료 후 서버에 적용 중이십니다.(밥모임 상태 변경은 완료되었습니다)
