### PR TITLE
토큰 재발급 과정 중 스켈레톤 UI 보여주기 

### DIFF
--- a/src/components/common/Layout/Header.tsx
+++ b/src/components/common/Layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@chakra-ui/react';
+import { Flex, Skeleton, SkeletonCircle } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import LoginButton from 'components/Login/LoginButton';
 import dynamic from 'next/dynamic';
@@ -9,13 +9,18 @@ import { isCheckingRefreshTokenState, isLoginState } from 'stores/auth';
 import { LoginModal } from 'types/modal';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
-const HeaderSkeleton = () => {
-  return <Skeleton width='4rem' height='1.75rem' />;
+const ProfileSkeleton = () => {
+  return (
+    <Flex alignItems='center'>
+      <Skeleton width='7rem' height='1.75rem' marginRight='0.5rem' />
+      <SkeletonCircle size='10' />
+    </Flex>
+  );
 };
 
 const DynamicUserProfile = dynamic(() => import('../UserProfile'), {
   ssr: false,
-  loading: () => <HeaderSkeleton />,
+  loading: () => <ProfileSkeleton />,
 });
 
 const Header = ({ isOpen, onClose, onOpen }: LoginModal) => {
@@ -40,7 +45,7 @@ const Header = ({ isOpen, onClose, onOpen }: LoginModal) => {
           <LoginButton isOpen={isOpen} onClose={onClose} onOpen={onOpen} />
         )
       ) : (
-        <HeaderSkeleton />
+        <ProfileSkeleton />
       )}
     </Container>
   );

--- a/src/components/common/Layout/Header.tsx
+++ b/src/components/common/Layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Skeleton, SkeletonCircle } from '@chakra-ui/react';
+import { Skeleton } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import LoginButton from 'components/Login/LoginButton';
 import dynamic from 'next/dynamic';
@@ -9,9 +9,13 @@ import { isCheckingRefreshTokenState, isLoginState } from 'stores/auth';
 import { LoginModal } from 'types/modal';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
+const HeaderSkeleton = () => {
+  return <Skeleton width='4rem' height='1.75rem' />;
+};
+
 const DynamicUserProfile = dynamic(() => import('../UserProfile'), {
   ssr: false,
-  loading: () => <SkeletonCircle />,
+  loading: () => <HeaderSkeleton />,
 });
 
 const Header = ({ isOpen, onClose, onOpen }: LoginModal) => {
@@ -36,7 +40,7 @@ const Header = ({ isOpen, onClose, onOpen }: LoginModal) => {
           <LoginButton isOpen={isOpen} onClose={onClose} onOpen={onOpen} />
         )
       ) : (
-        <Skeleton width='4rem' height='1.75rem' />
+        <HeaderSkeleton />
       )}
     </Container>
   );

--- a/src/components/common/Layout/Header.tsx
+++ b/src/components/common/Layout/Header.tsx
@@ -1,11 +1,11 @@
-import { SkeletonCircle } from '@chakra-ui/react';
+import { Skeleton, SkeletonCircle } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import LoginButton from 'components/Login/LoginButton';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
-import { isLoginState } from 'stores/auth';
+import { isCheckingRefreshTokenState, isLoginState } from 'stores/auth';
 import { LoginModal } from 'types/modal';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
@@ -16,6 +16,7 @@ const DynamicUserProfile = dynamic(() => import('../UserProfile'), {
 
 const Header = ({ isOpen, onClose, onOpen }: LoginModal) => {
   const isLogin = useRecoilValue(isLoginState);
+  const isCheckingRefreshToken = useRecoilValue(isCheckingRefreshTokenState);
 
   return (
     <Container>
@@ -28,10 +29,14 @@ const Header = ({ isOpen, onClose, onOpen }: LoginModal) => {
           style={{ marginLeft: '-40px' }}
         />
       </Link>
-      {isLogin ? (
-        <DynamicUserProfile />
+      {isCheckingRefreshToken ? (
+        isLogin ? (
+          <DynamicUserProfile />
+        ) : (
+          <LoginButton isOpen={isOpen} onClose={onClose} onOpen={onOpen} />
+        )
       ) : (
-        <LoginButton isOpen={isOpen} onClose={onClose} onOpen={onOpen} />
+        <Skeleton width='4rem' height='1.75rem' />
       )}
     </Container>
   );

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -7,7 +7,7 @@ import { ReactNode, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { silentLogin } from 'services/auth';
 import { isCheckingRefreshTokenState, isLoginState } from 'stores/auth';
-import theme from 'styles/chakra-theme';
+import theme from 'styles/chakraTheme';
 import { BaseFont } from 'styles/fonts';
 import globalStyle from 'styles/global';
 

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -6,16 +6,24 @@ import CreateCommunityDrawer from 'components/DraggableDrawer/CreateCommunityDra
 import { ReactNode, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { silentLogin } from 'services/auth';
-import { isLoginState } from 'stores/auth';
-import theme from 'styles/chakraTheme';
+import { isCheckingRefreshTokenState, isLoginState } from 'stores/auth';
+import theme from 'styles/chakra-theme';
 import { BaseFont } from 'styles/fonts';
 import globalStyle from 'styles/global';
 
 const Layout = ({ children }: { children: ReactNode }) => {
   const setLoginState = useSetRecoilState(isLoginState);
+  const setIsCheckingRefreshToken = useSetRecoilState(isCheckingRefreshTokenState);
 
   useEffect(() => {
-    silentLogin().then((res) => res && setLoginState(true));
+    (async () => {
+      try {
+        const token = await silentLogin();
+        token && setLoginState(true);
+      } finally {
+        setIsCheckingRefreshToken(true);
+      }
+    })();
   }, []);
 
   const { isOpen, onOpen, onClose } = useDisclosure(); // 로그인 모달

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -4,3 +4,8 @@ export const isLoginState = atom<boolean>({
   key: 'isLogin',
   default: false,
 });
+
+export const isCheckingRefreshTokenState = atom<boolean>({
+  key: 'isCheckingRefreshToken',
+  default: false,
+});


### PR DESCRIPTION
## 💡 Linked Issues

- close #128 

## 📖 구현 내용

- refresh token으로 accesstoken 불러오는 로직, 후처리를 then 대신 await~async로 수정 
- refresh token으로 accesstoken 불러오는 중일 때, 스켈레톤 UI 보여주도록 함
- 유저 프로필 불러오는 스켈레톤과 위 스켈레톤 -> headerSkeleton으로 통일
> 이전엔 로그인 버튼이 보였다가 유저프로필 불러오는 스켈레톤 UI로 보였음, pr에 첨부된 영상 참고
https://github.com/prgrms-web-devcourse/Team-Kkini-Mukvengers-FE/pull/111

## 🖼 구현 이미지

https://user-images.githubusercontent.com/70274947/224404997-c86d4a7e-3298-4b1b-9009-69ab6a3d042b.mov



## ✅ PR 포인트 & 궁금한 점
headerSkeleton를 header 컴포넌트 내에서 관리하는 데..분리할까요? 
