### PR TITLE
근처의 기준, 화면에 보이는 지도 반경으로 변경 & 에러 수정 

### DIFF
--- a/src/hooks/kakaoMap/useRecommendRandomRestaurant.ts
+++ b/src/hooks/kakaoMap/useRecommendRandomRestaurant.ts
@@ -36,7 +36,8 @@ const useRecommendRandomRestaurant = () => {
         kakaoMapHelpers.getCenter(kakaoMap);
       const nearbyRestaurants = await getNearbyRestaurants(
         currentLatitude,
-        currentLongitude
+        currentLongitude,
+        kakaoMap
       );
       const randomIndex = Math.floor(Math.random() * nearbyRestaurants.length);
       const randomRestaurant = nearbyRestaurants[randomIndex];

--- a/src/utils/helpers/kakaoMap.ts
+++ b/src/utils/helpers/kakaoMap.ts
@@ -91,9 +91,9 @@ export const kakaoMapAddEventListener = (
 
 export const getNearbyRestaurants = (
   latitude: number,
-  longitude: number
+  longitude: number,
+  kakaoMap: kakao.maps.Map
 ): Promise<kakao.maps.services.PlacesSearchResultItem[]> => {
-  const DEFAULT_RADIUS = 300;
   const KAKAO_RESTAURANT_CATEGORY_CODE = 'FD6';
 
   const nearbyRestaurants: kakao.maps.services.PlacesSearchResultItem[] = [];
@@ -101,8 +101,9 @@ export const getNearbyRestaurants = (
   const placesSearchOptions: kakao.maps.services.PlacesSearchOptions = {
     x: longitude,
     y: latitude,
-    radius: DEFAULT_RADIUS,
+    radius: kakaoMapHelpers.getDistanceFromLongitude(kakaoMap),
   };
+  console.log(kakaoMapHelpers.getDistanceFromLongitude(kakaoMap));
 
   return new Promise((resolve, reject) => {
     kakaoPlacesService.categorySearch(

--- a/src/utils/helpers/kakaoMap.ts
+++ b/src/utils/helpers/kakaoMap.ts
@@ -103,7 +103,6 @@ export const getNearbyRestaurants = (
     y: latitude,
     radius: kakaoMapHelpers.getDistanceFromLongitude(kakaoMap),
   };
-  console.log(kakaoMapHelpers.getDistanceFromLongitude(kakaoMap));
 
   return new Promise((resolve, reject) => {
     kakaoPlacesService.categorySearch(

--- a/src/utils/helpers/kakaoMap.ts
+++ b/src/utils/helpers/kakaoMap.ts
@@ -77,7 +77,7 @@ export const kakaoMapHelpers = {
     };
     const gapOfLongitude = Number(Math.abs(centerLongitude - northLongitude).toFixed(3));
     const distance = (LONGITUDE.METER * gapOfLongitude) / LONGITUDE.DEGREE;
-    return distance;
+    return Math.floor(distance);
   },
 };
 


### PR DESCRIPTION
## 💡 Linked Issues

- close #158 

## 📖 구현 내용

- 근처 밥모임 불러오는 api의 payload중 distance 정수로 수정 
- 근처 랜덤맛집 뽑는 로직 중, 근처의 기준: 300 고정값 ->  화면에 보이는 지도 반경으로 변경 

## 🖼 구현 이미지
랜덤맛집 뽑을 때, radiust 설정값 콘솔에 찍고있음 
![test](https://user-images.githubusercontent.com/70274947/224796356-f0b1a524-ce14-4a90-80d9-a165c4d5fa70.gif)

