### PR TITLE
랜덤 맛집 커스텀 오버레이 누르면 지도가 이동하는 기능 삭제

### DIFF
--- a/src/components/KakaoMap/index.tsx
+++ b/src/components/KakaoMap/index.tsx
@@ -161,11 +161,6 @@ const KakaoMap = () => {
     );
     const handleClickRandomRestaurantCustomOverlay = () => {
       setRandomRestaurantDrawerOpen(true);
-      kakaoMapHelpers.panto({
-        kakaoMap,
-        latitude: randomRestaurant.customOverlay?.getPosition().getLat(),
-        longitude: randomRestaurant.customOverlay?.getPosition().getLng(),
-      });
     };
     randomRestaurantCustomOverlayElement?.addEventListener(
       'click',


### PR DESCRIPTION
## 💡 Linked Issues

- close #177 

## 📖 구현 내용

- 랜덤 맛집 커스텀 오버레이 누르면 지도가 이동하는 기능 삭제

## 🖼 구현 이미지
![panto](https://user-images.githubusercontent.com/93233930/226977798-2e68f95e-35a5-4cb2-b9b1-891d96d5b8cb.gif)

## ✅ PR 포인트 & 궁금한 점
