### PR TITLE
지도에 밥모임 렌더링하는 로직 리팩토링 

### DIFF
--- a/src/hooks/useNearFoodParty.ts
+++ b/src/hooks/useNearFoodParty.ts
@@ -49,8 +49,8 @@ const useNearFoodParty = () => {
   const getNearFoodParty = async (props: NearFoodPartyProps) => {
     const foodPartyResponse = await fetchNearFoodPartyList({ ...props });
     const processedFoodParty = getOneFoodPartyPerRestaurant(foodPartyResponse);
-    const newNearFooParty = addFoodPartyOverlay(processedFoodParty);
-    setNearFoodParty(newNearFooParty);
+    const newNearFoodParty = addFoodPartyOverlay(processedFoodParty);
+    setNearFoodParty(newNearFoodParty);
   };
 
   const addFoodPartyOverlay = (foodParty: NearFoodPartyItem[]) => {

--- a/src/hooks/useNearFoodParty.ts
+++ b/src/hooks/useNearFoodParty.ts
@@ -66,7 +66,7 @@ const useNearFoodParty = () => {
     });
   };
 
-  const handleOnClickRestaurant = async (storeId: number) => {
+  const handleClickFoodPartyOverlay = async (storeId: number) => {
     const restaurant = await fetchRestaurantDetail(storeId);
     setClickedRestaurant(restaurant);
   };
@@ -82,7 +82,7 @@ const useNearFoodParty = () => {
         getElement(`#food-party-overlay-container-${storeId}`)?.addEventListener(
           'click',
           () => {
-            handleOnClickRestaurant(storeId);
+            handleClickFoodPartyOverlay(storeId);
           }
         );
       }
@@ -94,7 +94,7 @@ const useNearFoodParty = () => {
         nearFoodParty.forEach(({ storeId, overlay }) => {
           getElement(`#food-party-overlay-container-${storeId}`)?.removeEventListener(
             'click',
-            () => handleOnClickRestaurant
+            () => handleClickFoodPartyOverlay
           );
           if (overlay) {
             overlay.setMap(null);

--- a/src/hooks/useNearFoodParty.ts
+++ b/src/hooks/useNearFoodParty.ts
@@ -74,7 +74,7 @@ const useNearFoodParty = () => {
   useEffect(() => {
     if (!kakaoMap || !nearFoodParty.length) return;
 
-    // overlay 지도에 렌더링 & 이벤트 걸기
+    // overlay 지도에 렌더링 & 이벤트 연결
     nearFoodParty.forEach(({ overlay, storeId }) => {
       if (overlay) {
         overlay.setMap(kakaoMap);
@@ -89,7 +89,7 @@ const useNearFoodParty = () => {
     });
 
     return () => {
-      // 이전 오버레이 삭제 & 이벤트 제거
+      // 그려져있던 overlay 삭제 & 이벤트 제거
       if (nearFoodParty.length) {
         nearFoodParty.forEach(({ storeId, overlay }) => {
           getElement(`#food-party-overlay-container-${storeId}`)?.removeEventListener(
@@ -102,7 +102,7 @@ const useNearFoodParty = () => {
         });
       }
     };
-  }, [nearFoodParty]);
+  }, [nearFoodParty, kakaoMap]);
 
   return {
     nearFoodParty,

--- a/src/hooks/useNearFoodParty.ts
+++ b/src/hooks/useNearFoodParty.ts
@@ -46,21 +46,21 @@ const useNearFoodParty = () => {
   const [nearFoodParty, setNearFoodParty] = useState<NearFoodPartyItem[]>([]);
   const [clickedRestaurant, setClickedRestaurant] = useState<Restaurant>();
 
-  const getNearFoodParty = async (props: NearFoodPartyProps) => {
-    const foodPartyResponse = await fetchNearFoodPartyList({ ...props });
+  const getNearFoodParty = async (params: NearFoodPartyProps) => {
+    const foodPartyResponse = await fetchNearFoodPartyList({ ...params });
     const processedFoodParty = getOneFoodPartyPerRestaurant(foodPartyResponse);
     const newNearFoodParty = addFoodPartyOverlay(processedFoodParty);
     setNearFoodParty(newNearFoodParty);
   };
 
   const addFoodPartyOverlay = (foodParty: NearFoodPartyItem[]) => {
-    return foodParty.map((props) => {
-      const { latitude, longitude, placeName, storeId } = props;
+    return foodParty.map((foodPartyItem) => {
+      const { latitude, longitude, placeName, storeId } = foodPartyItem;
       const content = createFoodPartyOverlay({ latitude, longitude, placeName, storeId });
       const overlay = kakaoMapHelpers.makeCustomOverlay(latitude, longitude, content);
 
       return {
-        ...props,
+        ...foodPartyItem,
         overlay,
       };
     });

--- a/src/hooks/useNearFoodParty.ts
+++ b/src/hooks/useNearFoodParty.ts
@@ -5,7 +5,7 @@ import { fetchRestaurantDetail } from 'services/restaurant';
 import { NearFoodPartyItem, NearFoodPartyProps } from 'types/foodParty';
 import { Restaurant } from 'types/restaurant';
 import { getElement } from 'utils/helpers/elementHandler';
-import { getUniqueRestaurant } from 'utils/helpers/foodParty';
+import { getOneFoodPartyPerRestaurant } from 'utils/helpers/foodParty';
 import { kakaoMapHelpers } from 'utils/helpers/kakaoMap';
 
 const FOOD_PARTY_BADGE_IMAGE_FILE_PATH = 'images/rice.png';
@@ -42,7 +42,7 @@ const createFoodPartyOverlay = ({ placeName, storeId }: NearFoodPartyItem) => {
 };
 
 const useNearFoodParty = () => {
-  const { kakaoMap, setKakaoMap } = useKakaoMapContext();
+  const { kakaoMap } = useKakaoMapContext();
   const [nearFoodParty, setNearFoodParty] = useState<NearFoodPartyItem[]>([]);
   const [foodPartyOverlay, setFoodPartyOverlay] = useState<kakao.maps.CustomOverlay[]>(
     []
@@ -50,9 +50,9 @@ const useNearFoodParty = () => {
   const [clickedRestaurant, setClickedRestaurant] = useState<Restaurant>();
 
   const getNearFoodParty = async (props: NearFoodPartyProps) => {
-    const nearFoodParty = await fetchNearFoodPartyList({ ...props });
-    const uniqueRestaurant = getUniqueRestaurant(nearFoodParty);
-    setNearFoodParty(uniqueRestaurant);
+    const newNearFoodParty = await fetchNearFoodPartyList({ ...props });
+    const processedFoodParty = getOneFoodPartyPerRestaurant(newNearFoodParty);
+    setNearFoodParty(processedFoodParty);
   };
 
   const handleOnClickRestaurant = async (storeId: number) => {
@@ -65,7 +65,7 @@ const useNearFoodParty = () => {
 
     // 현재있는 마커 지우기
     if (foodPartyOverlay.length) {
-      foodPartyOverlay.forEach((marker) => marker.setMap(null));
+      foodPartyOverlay.forEach((overlay) => overlay.setMap(null));
     }
 
     const newFoodPartyOverlayList = nearFoodParty.map(

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -102,6 +102,7 @@ export type NearFoodPartyItem = {
   longitude: number;
   storeId: number;
   placeName: string;
+  overlay?: kakao.maps.CustomOverlay;
 };
 
 export type NearFoodPartyProps = {

--- a/src/utils/helpers/foodParty.ts
+++ b/src/utils/helpers/foodParty.ts
@@ -93,7 +93,7 @@ const NotMemberText: {
   '식사 완료': '',
 };
 
-export const getUniqueRestaurant = (foodParty: NearFoodPartyItem[]) => {
+export const getOneFoodPartyPerRestaurant = (foodParty: NearFoodPartyItem[]) => {
   return foodParty.filter(
     ({ storeId }, index, array) =>
       index === array.findIndex((item) => item.storeId === storeId)


### PR DESCRIPTION
## 📖 구현 내용

- 밥모임 상태값, 밥모임 overlay -> `nearFoodParty` 상태값 하나로 관리
  - 그려져있는 밥모임에 이벤트 제거, 밥모임 제거를 한 루프에 해결 
- 밥모임 overlay 생성 / 지도에 렌더 + 이벤트 바인딩 -> 로직 분리함 
   - 원래는 생성, 렌더, 이벤트 바인딩 한번에 useEffect에서 작업하고 있었음
- 밥모임에서 가게별 1개만 남기는 함수 네이밍 수정 `getUniqueRestaurant` -> `getOneFoodPartyPerRestaurant`

## 🖼 구현 이미지
![giphy](https://user-images.githubusercontent.com/70274947/227149762-37911879-fc04-42cb-8140-0d3b5cd699e0.gif)


## ✅ PR 포인트 & 궁금한 점
현재는 그려져있는 밥모임을 다 지우고, 현재 받아온 밥모임을 그리는 로직인데, 
밥모임이 엄청 많아지면 성능상 안좋을 거 같아서! 
이후에 그려져있는 밥모임, 받아온 밥모임이 동일하다면 그대로 두는 로직으로 개선해볼게용 