### PR TITLE
로그인 후, home 외에 다른 페이지로 갈 수 있도록 확장 

### DIFF
--- a/src/components/Login/LoginButton.tsx
+++ b/src/components/Login/LoginButton.tsx
@@ -5,30 +5,38 @@ import GoogleButton from 'components/Login/OAuth/GoogleButton';
 import KakaoButton from 'components/Login/OAuth/KakaoButton';
 import Image from 'next/image';
 import { useRecoilState } from 'recoil';
-import { loginDrawerOpenState } from 'stores/drawer';
+import { loginDrawerState } from 'stores/drawer';
+import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 const LoginButton = () => {
-  const [loginDrawerOpen, setLoginDrawerOpen] = useRecoilState(loginDrawerOpenState);
+  const [loginDrawer, setLoginDrawer] = useRecoilState(loginDrawerState);
+
+  const handleClickLoginButton = () => {
+    setLoginDrawer({ isOpen: true, urlAfterLogin: ROUTING_PATHS.HOME });
+  };
+  const handleClickCloseButton = () => {
+    setLoginDrawer({ isOpen: false, urlAfterLogin: ROUTING_PATHS.HOME });
+  };
 
   return (
     <>
       <Button
-        onClick={() => setLoginDrawerOpen(true)}
+        onClick={handleClickLoginButton}
         width='4rem'
         height='2.5rem'
         style={{ backgroundColor: '#F6BB43' }}>
         로그인
       </Button>
       <BottomDrawer
-        isOpen={loginDrawerOpen}
-        onClose={() => setLoginDrawerOpen(false)}
+        isOpen={loginDrawer.isOpen}
+        onClose={handleClickCloseButton}
         header={
           <Flex justifyContent='space-between'>
             <Text fontSize='1.5rem'>로그인</Text>
             <Image
               src='/images/delete-btn.svg'
               alt='modal-close-button'
-              onClick={() => setLoginDrawerOpen(false)}
+              onClick={handleClickCloseButton}
               width='25'
               height='25'
             />
@@ -40,8 +48,8 @@ const LoginButton = () => {
               지금 로그인해서 맛집을 함께 경험해보세요
             </Text>
             <Flex direction='column' gap='0.5rem'>
-              <KakaoButton />
-              <GoogleButton />
+              <KakaoButton urlAfterLogin={loginDrawer.urlAfterLogin} />
+              <GoogleButton urlAfterLogin={loginDrawer.urlAfterLogin} />
             </Flex>
           </Box>
         }

--- a/src/components/Login/OAuth/GoogleButton.tsx
+++ b/src/components/Login/OAuth/GoogleButton.tsx
@@ -1,11 +1,12 @@
 import { Flex, Text } from '@chakra-ui/react';
 import Button from 'components/common/Button';
 import { FcGoogle } from 'react-icons/fc';
+import { RedirectUrlType } from 'types/auth';
 
-const GoogleButton = () => {
+const GoogleButton = ({ urlAfterLogin }: RedirectUrlType) => {
   return (
     <a
-      href={`${process.env.NEXT_PUBLIC_API_END_POINT}/oauth2/authorization/google?redirect_uri=${process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URL}`}>
+      href={`${process.env.NEXT_PUBLIC_API_END_POINT}/oauth2/authorization/google?redirect_uri=${process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URL}?urlAfterLogin=${urlAfterLogin}`}>
       <Button
         style={{
           color: '#777776',

--- a/src/components/Login/OAuth/KakaoButton.tsx
+++ b/src/components/Login/OAuth/KakaoButton.tsx
@@ -1,11 +1,12 @@
 import { Flex, Text } from '@chakra-ui/react';
 import Button from 'components/common/Button';
 import { ImBubble } from 'react-icons/im';
+import { RedirectUrlType } from 'types/auth';
 
-const KakaoButton = () => {
+const KakaoButton = ({ urlAfterLogin }: RedirectUrlType) => {
   return (
     <a
-      href={`${process.env.NEXT_PUBLIC_API_END_POINT}/oauth2/authorization/kakao?redirect_uri=${process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URL}`}>
+      href={`${process.env.NEXT_PUBLIC_API_END_POINT}/oauth2/authorization/kakao?redirect_uri=${process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URL}?urlAfterLogin=${urlAfterLogin}`}>
       <Button
         style={{
           color: 'black',

--- a/src/components/Restaurant/RestaurantBottomDrawer.tsx
+++ b/src/components/Restaurant/RestaurantBottomDrawer.tsx
@@ -5,8 +5,9 @@ import Category from 'components/common/Category';
 import { BiRightArrowCircle } from 'react-icons/bi';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { isLoginState } from 'stores/auth';
-import { loginDrawerOpenState } from 'stores/drawer';
+import { loginDrawerState } from 'stores/drawer';
 import { Restaurant } from 'types/restaurant';
+import ROUTING_PATHS from 'utils/constants/routingPaths';
 import { getCategoryArray, getPhotoUrlsArray } from 'utils/helpers/foodParty';
 
 type RestaurantBottomDrawerProps = {
@@ -25,7 +26,17 @@ const RestaurantBottomDrawer = ({
   const categories = getCategoryArray(restaurant.categories);
   const photoUrls = getPhotoUrlsArray(restaurant.photoUrls || '');
   const isLogin = useRecoilValue(isLoginState);
-  const setLoginDrawerOpen = useSetRecoilState(loginDrawerOpenState);
+  const setLoginDrawerOpen = useSetRecoilState(loginDrawerState);
+
+  const handleClickButtonJoinAfterLogin = () => {
+    setLoginDrawerOpen({
+      isOpen: true,
+      urlAfterLogin: ROUTING_PATHS.FOOD_PARTY.LIST.RESTAURANT(
+        restaurant.placeId,
+        restaurant.placeName
+      ),
+    });
+  };
 
   return (
     <BottomDrawer
@@ -93,7 +104,7 @@ const RestaurantBottomDrawer = ({
           )}
           {onClickJoinButton && (
             <Button
-              onClick={isLogin ? onClickJoinButton : () => setLoginDrawerOpen(true)}
+              onClick={isLogin ? onClickJoinButton : handleClickButtonJoinAfterLogin}
               width='100%'
               style={{
                 backgroundColor: 'primary',

--- a/src/components/Restaurant/RestaurantBottomDrawer.tsx
+++ b/src/components/Restaurant/RestaurantBottomDrawer.tsx
@@ -28,7 +28,7 @@ const RestaurantBottomDrawer = ({
   const isLogin = useRecoilValue(isLoginState);
   const setLoginDrawerOpen = useSetRecoilState(loginDrawerState);
 
-  const handleClickButtonJoinAfterLogin = () => {
+  const handleClickJoinButtonAfterLogin = () => {
     setLoginDrawerOpen({
       isOpen: true,
       urlAfterLogin: ROUTING_PATHS.FOOD_PARTY.LIST.RESTAURANT(
@@ -104,7 +104,7 @@ const RestaurantBottomDrawer = ({
           )}
           {onClickJoinButton && (
             <Button
-              onClick={isLogin ? onClickJoinButton : handleClickButtonJoinAfterLogin}
+              onClick={isLogin ? onClickJoinButton : handleClickJoinButtonAfterLogin}
               width='100%'
               style={{
                 backgroundColor: 'primary',

--- a/src/components/common/Layout/Navigation/index.tsx
+++ b/src/components/common/Layout/Navigation/index.tsx
@@ -7,7 +7,7 @@ import { BsMap } from 'react-icons/bs';
 import { CiForkAndKnife, CiReceipt } from 'react-icons/ci';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { isLoginState } from 'stores/auth';
-import { loginDrawerOpenState } from 'stores/drawer';
+import { loginDrawerState } from 'stores/drawer';
 import { foodPartyCreateDrawerOpenState } from 'stores/drawer';
 import { foodPartyCreateDrawerInitState } from 'stores/drawer';
 import { NavigationButtonProps } from 'types/navigation';
@@ -17,14 +17,14 @@ const Navigation = () => {
   const [foodPartyCreateDrawerOpen, setFoodPartyCreateDrawerOpen] = useRecoilState(
     foodPartyCreateDrawerOpenState
   );
-  const setLoginDrawerOpen = useSetRecoilState(loginDrawerOpenState);
+  const setLoginDrawer = useSetRecoilState(loginDrawerState);
   const isLogin = useRecoilValue(isLoginState);
   const [isInit, setIsInit] = useRecoilState(foodPartyCreateDrawerInitState);
   const router = useRouter();
 
   const checkLoginUser = () => {
     if (!isLogin) {
-      setLoginDrawerOpen(true);
+      setLoginDrawer({ isOpen: true, urlAfterLogin: ROUTING_PATHS.HOME });
     }
     return isLogin;
   };

--- a/src/pages/oauth.tsx
+++ b/src/pages/oauth.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@chakra-ui/react';
 import { setAccessToken } from 'apis/axios';
+import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -13,17 +14,25 @@ const OAuthLogin = () => {
 
   useEffect(() => {
     const token = router.query.accessToken as string;
+    const urlAfterLogin = router.query.urlAfterLogin as string;
+
     if (token) {
       setAccessToken(token);
       setLoginState(true);
-      router.push(ROUTING_PATHS.HOME, undefined, { shallow: true });
+      router.push(urlAfterLogin || ROUTING_PATHS.HOME, undefined, { shallow: true });
     }
   }, [router]);
 
   return (
-    <Flex height='100%' justifyContent='center' alignItems='center'>
-      <Image src='/images/sausage.gif' alt='' width={480} height={480} />
-    </Flex>
+    <>
+      {router.query.error ? (
+        <GoHomeWhenErrorInvoked />
+      ) : (
+        <Flex height='100%' justifyContent='center' alignItems='center'>
+          <Image src='/images/sausage.gif' alt='' width={480} height={480} />
+        </Flex>
+      )}
+    </>
   );
 };
 

--- a/src/stores/drawer.ts
+++ b/src/stores/drawer.ts
@@ -1,4 +1,5 @@
 import { atom } from 'recoil';
+import { RedirectUrlType } from 'types/auth';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 export const foodPartyCreateDrawerOpenState = atom<boolean>({
@@ -6,7 +7,7 @@ export const foodPartyCreateDrawerOpenState = atom<boolean>({
   default: false,
 });
 
-export const loginDrawerState = atom<{ isOpen: boolean; urlAfterLogin: string }>({
+export const loginDrawerState = atom<{ isOpen: boolean } & RedirectUrlType>({
   key: 'loginDrawerOpen',
   default: { isOpen: false, urlAfterLogin: ROUTING_PATHS.HOME },
 });

--- a/src/stores/drawer.ts
+++ b/src/stores/drawer.ts
@@ -1,13 +1,14 @@
 import { atom } from 'recoil';
+import ROUTING_PATHS from 'utils/constants/routingPaths';
 
 export const foodPartyCreateDrawerOpenState = atom<boolean>({
   key: 'foodPartyCreateDrawerOpen',
   default: false,
 });
 
-export const loginDrawerOpenState = atom<boolean>({
+export const loginDrawerState = atom<{ isOpen: boolean; urlAfterLogin: string }>({
   key: 'loginDrawerOpen',
-  default: false,
+  default: { isOpen: false, urlAfterLogin: ROUTING_PATHS.HOME },
 });
 
 export const restaurantDrawerOpenState = atom<boolean>({

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -12,3 +12,7 @@ export type UserProfile = {
   tasteScore: number;
   mannerScore: number;
 };
+
+export type RedirectUrlType = {
+  urlAfterLogin: string;
+};


### PR DESCRIPTION
## 💡 Linked Issues

- close #144

## 📖 구현 내용

- 로그인 후 home외에 다른 페이지로 이동할 수 있도록, redirect_uri에 query로 urlAfterLogin 설정해둡니다. 
- 해당 query를 이용해 라우팅 처리를 합니다. 없으면 home으로 가도록 연결해놨습니다. 
- (에러처리) 백엔드쪽에서는 소셜 로그인 중에 에러나는 경우가 거의 없다고 했지만, 에러처리는 해두는 게 좋을 거 같다고해서, 에러가 날 경우, 에러 컴포넌트 보여주도록 처리해뒀습니다. 
     - 에러가 날 경우엔, query에 error가 옵니다. 이 조건으로 처리했습니다. 

## 🖼 구현 이미지
![로그인후밥모임참여](https://user-images.githubusercontent.com/70274947/229042178-b583e225-c6dd-4e74-8f0a-df21d85f675d.gif)


## ✅ PR 포인트 & 궁금한 점
> (에러처리) 백엔드쪽에서는 소셜 로그인 중에 에러나는 경우가 거의 없다고 했지만, 에러처리는 해두는 게 좋을 거 같다고해서, 에러가 날 경우, 에러 컴포넌트 보여주도록 처리해뒀습니다.

이게 괜찮은 에러처리인지 애매하네요..어떻게 생각하시나요? 에러 메시지라도 바꿔놓을까요? 

- 전반적으로 네이밍 가독성 괜찮은지 궁금합니다. 