### PR TITLE
Google Analytics 페이지 추적을 위해 각 페이지마다 title 태그 추가

### DIFF
--- a/src/components/FoodParty/Create/index.tsx
+++ b/src/components/FoodParty/Create/index.tsx
@@ -16,6 +16,7 @@ import AccordionHeader from 'components/common/Accordion/AccordionHeader';
 import Button from 'components/common/Button';
 import { useCreateFoodParty } from 'hooks/query/useFoodParty';
 import moment, { Moment } from 'moment';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -100,140 +101,145 @@ const FoodPartyCreateForm = () => {
   }, [router, selectedRestaurant, toast]);
 
   return (
-    <Flex align='center' justify='center' backgroundColor='subBackground' h='100%'>
-      <Box
-        w='90%'
-        h='95%'
-        bgColor='white'
-        borderRadius='8px'
-        p='2rem'
-        position='relative'>
-        <Text fontSize='xl' fontWeight={600}>
-          어떤 밥모임을 만들까요?
-        </Text>
-        <Form onSubmit={handleSubmit(onSubmit)}>
-          <FormControl isRequired isInvalid={!!errors.name}>
-            <Input
-              type='text'
-              {...register('name', {
-                required: true,
-                minLength: {
-                  value: 2,
-                  message: '제목을 2자 이상으로 적어주세요',
-                },
-                maxLength: {
-                  value: 15,
-                  message: '제목을 15자 이하로 적어주세요',
-                },
-              })}
-              bgColor='transparent'
-              placeholder='제목을 입력해주세요!'
-              size='lg'
-              borderColor='transparent'
-              focusBorderColor='gray.100'
-              my='0.25rem'
-            />
-            <FormErrorMessage mb='0.25rem'>{errors.name?.message}</FormErrorMessage>
-          </FormControl>
-          {/** Todo: 제목을 입력하면 Accordion이 보이게 변경하려고 함 */}
-          <Accordion allowToggle defaultIndex={[0]}>
-            <AccordionItem>
-              <Flex align='center'>
-                <Flex
-                  as='span'
-                  flex='1'
-                  h={35}
-                  fontWeight={600}
-                  pl='1rem'
-                  justify='flex-start'
-                  align='center'>
-                  가게명
-                </Flex>
-                <Text color='gray.500' pr='2rem'>
-                  {selectedRestaurant.placeName}
-                </Text>
-              </Flex>
-            </AccordionItem>
-            {/** 밥모임 카테고리 */}
-            <AccordionItem>
-              <AccordionHeader>
-                <Box as='span' flex='1' fontWeight={600} textAlign='left'>
-                  카테고리
-                </Box>
-                <Box fontSize='sm' color='gray.500' pr={1.5}>
-                  {categoryState}
-                </Box>
-              </AccordionHeader>
-              <AccordionBody>
-                <FoodPartyCategoryItem onClick={handleClickCategory} />
-              </AccordionBody>
-            </AccordionItem>
-            {/** 밥모임 인원 */}
-            <AccordionItem>
-              <FoodPartyCapacity<PartyFormType>
-                register={register}
-                registerRules={{
+    <>
+      <Head>
+        <title>{selectedRestaurant.placeName} 음식점 밥모임 생성하기</title>
+      </Head>
+      <Flex align='center' justify='center' backgroundColor='subBackground' h='100%'>
+        <Box
+          w='90%'
+          h='95%'
+          bgColor='white'
+          borderRadius='8px'
+          p='2rem'
+          position='relative'>
+          <Text fontSize='xl' fontWeight={600}>
+            어떤 밥모임을 만들까요?
+          </Text>
+          <Form onSubmit={handleSubmit(onSubmit)}>
+            <FormControl isRequired isInvalid={!!errors.name}>
+              <Input
+                type='text'
+                {...register('name', {
                   required: true,
-                  minLength: 1,
-                }}
-                registerName={'capacity'}
+                  minLength: {
+                    value: 2,
+                    message: '제목을 2자 이상으로 적어주세요',
+                  },
+                  maxLength: {
+                    value: 15,
+                    message: '제목을 15자 이하로 적어주세요',
+                  },
+                })}
+                bgColor='transparent'
+                placeholder='제목을 입력해주세요!'
+                size='lg'
+                borderColor='transparent'
+                focusBorderColor='gray.100'
+                my='0.25rem'
               />
-            </AccordionItem>
-            {/** 밥모임 날짜 */}
-            <AccordionItem>
-              <AccordionHeader>
-                <Box as='span' flex='1' fontWeight={600} textAlign='left'>
-                  날짜
-                </Box>
-                <Box fontSize='sm' color='gray.500' pr={1.5}>
-                  {currentDate}
-                </Box>
-              </AccordionHeader>
-              <AccordionBody>
-                <FoodPartyCalendar date={date} onChange={handleClickDate} />
-              </AccordionBody>
-            </AccordionItem>
-            {/** 밥모임 시간 */}
-            <AccordionItem>
-              <AccordionHeader>
-                <Box as='span' flex='1' fontWeight={600} textAlign='left'>
-                  시간
-                </Box>
-                <Box fontSize='sm' color='gray.500' pr={1.5}>
-                  {currentTime}
-                </Box>
-              </AccordionHeader>
-              <AccordionBody>
-                <FoodPartyTimePicker value={time} onChange={handleClickTime} />
-              </AccordionBody>
-            </AccordionItem>
-            {/** 밥모임 설명  */}
-            <AccordionItem>
-              <AccordionHeader>
-                <Box as='span' flex='1' fontWeight={600} textAlign='left'>
-                  밥모임 설명
-                </Box>
-              </AccordionHeader>
-              <AccordionBody>
-                <Textarea
-                  {...register('content', {
-                    required: false,
-                  })}></Textarea>
-              </AccordionBody>
-            </AccordionItem>
-          </Accordion>
-          <Button
-            type='submit'
-            width='100%'
-            style={{
-              backgroundColor: 'primary',
-              color: 'white',
-            }}>
-            다음
-          </Button>
-        </Form>
-      </Box>
-    </Flex>
+              <FormErrorMessage mb='0.25rem'>{errors.name?.message}</FormErrorMessage>
+            </FormControl>
+            {/** Todo: 제목을 입력하면 Accordion이 보이게 변경하려고 함 */}
+            <Accordion allowToggle defaultIndex={[0]}>
+              <AccordionItem>
+                <Flex align='center'>
+                  <Flex
+                    as='span'
+                    flex='1'
+                    h={35}
+                    fontWeight={600}
+                    pl='1rem'
+                    justify='flex-start'
+                    align='center'>
+                    가게명
+                  </Flex>
+                  <Text color='gray.500' pr='2rem'>
+                    {selectedRestaurant.placeName}
+                  </Text>
+                </Flex>
+              </AccordionItem>
+              {/** 밥모임 카테고리 */}
+              <AccordionItem>
+                <AccordionHeader>
+                  <Box as='span' flex='1' fontWeight={600} textAlign='left'>
+                    카테고리
+                  </Box>
+                  <Box fontSize='sm' color='gray.500' pr={1.5}>
+                    {categoryState}
+                  </Box>
+                </AccordionHeader>
+                <AccordionBody>
+                  <FoodPartyCategoryItem onClick={handleClickCategory} />
+                </AccordionBody>
+              </AccordionItem>
+              {/** 밥모임 인원 */}
+              <AccordionItem>
+                <FoodPartyCapacity<PartyFormType>
+                  register={register}
+                  registerRules={{
+                    required: true,
+                    minLength: 1,
+                  }}
+                  registerName={'capacity'}
+                />
+              </AccordionItem>
+              {/** 밥모임 날짜 */}
+              <AccordionItem>
+                <AccordionHeader>
+                  <Box as='span' flex='1' fontWeight={600} textAlign='left'>
+                    날짜
+                  </Box>
+                  <Box fontSize='sm' color='gray.500' pr={1.5}>
+                    {currentDate}
+                  </Box>
+                </AccordionHeader>
+                <AccordionBody>
+                  <FoodPartyCalendar date={date} onChange={handleClickDate} />
+                </AccordionBody>
+              </AccordionItem>
+              {/** 밥모임 시간 */}
+              <AccordionItem>
+                <AccordionHeader>
+                  <Box as='span' flex='1' fontWeight={600} textAlign='left'>
+                    시간
+                  </Box>
+                  <Box fontSize='sm' color='gray.500' pr={1.5}>
+                    {currentTime}
+                  </Box>
+                </AccordionHeader>
+                <AccordionBody>
+                  <FoodPartyTimePicker value={time} onChange={handleClickTime} />
+                </AccordionBody>
+              </AccordionItem>
+              {/** 밥모임 설명  */}
+              <AccordionItem>
+                <AccordionHeader>
+                  <Box as='span' flex='1' fontWeight={600} textAlign='left'>
+                    밥모임 설명
+                  </Box>
+                </AccordionHeader>
+                <AccordionBody>
+                  <Textarea
+                    {...register('content', {
+                      required: false,
+                    })}></Textarea>
+                </AccordionBody>
+              </AccordionItem>
+            </Accordion>
+            <Button
+              type='submit'
+              width='100%'
+              style={{
+                backgroundColor: 'primary',
+                color: 'white',
+              }}>
+              다음
+            </Button>
+          </Form>
+        </Box>
+      </Flex>
+    </>
   );
 };
 

--- a/src/components/FoodParty/FoodPartyList.tsx
+++ b/src/components/FoodParty/FoodPartyList.tsx
@@ -7,7 +7,7 @@ type FoodPartyListProps = {
   isMyFoodParty: boolean;
   foodPartyList: FoodParty[];
   onClickViewButton: (partyId: number) => void;
-  onClickReviewButton?: (partyId: number) => void;
+  onClickReviewButton?: (partyId: number, partyName: string) => void;
   onClickCreateFoodPartyButton?: () => void;
 };
 

--- a/src/components/FoodParty/FoodPartyListItem.tsx
+++ b/src/components/FoodParty/FoodPartyListItem.tsx
@@ -18,7 +18,7 @@ type FoodPartyListItemProps = {
   isMyFoodParty: boolean;
   party: FoodParty;
   onClickViewButton: (partyId: number) => void;
-  onClickReviewButton?: (partyId: number) => void;
+  onClickReviewButton?: (partyId: number, partyName: string) => void;
 };
 
 const FoodPartyListItem = ({
@@ -68,7 +68,7 @@ const FoodPartyListItem = ({
           {isMyFoodParty && party.crewStatus === '식사 완료' && (
             <Button
               onClick={() => {
-                onClickReviewButton && onClickReviewButton(party.id);
+                onClickReviewButton && onClickReviewButton(party.id, party.name);
               }}
               fontWeight='semibold'
               fontSize='14px'>

--- a/src/pages/food-party/application.tsx
+++ b/src/pages/food-party/application.tsx
@@ -16,7 +16,7 @@ const Application = () => {
   return (
     <>
       <Head>
-        <title>Application</title>
+        <title>신청서 목록</title>
       </Head>
       <Heading size='lg' padding='1rem'>
         신청서

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -148,6 +148,9 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
 
   return (
     <>
+      <Head>
+        <title>{foodPartyDetail?.name} - 밥모임 상세</title>
+      </Head>
       {isSuccess ? (
         <Flex
           position='relative'

--- a/src/pages/food-party/detail/chat/[roomId].tsx
+++ b/src/pages/food-party/detail/chat/[roomId].tsx
@@ -168,6 +168,9 @@ const FoodPartyDetailChat = ({ roomId }: { roomId: string }) => {
 
   return (
     <>
+      <Head>
+        <title>{foodPartyDetail?.name} - 밥모임 채팅방</title>
+      </Head>
       {!isErrorConnectingSocket &&
       isSuccessGettingExistingMessageList &&
       isSuccessGettingUserInformation &&

--- a/src/pages/food-party/list/my.tsx
+++ b/src/pages/food-party/list/my.tsx
@@ -14,8 +14,8 @@ const MyFoodPartyList = () => {
   const handleClickViewFoodPartyButton = (partyId: number) => {
     router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.INFORMATION(partyId));
   };
-  const handleClickReviewFoodPartyButton = (partyId: number) => {
-    router.push(ROUTING_PATHS.FOOD_PARTY.REVIEW(partyId));
+  const handleClickReviewFoodPartyButton = (partyId: number, partyName: string) => {
+    router.push(ROUTING_PATHS.FOOD_PARTY.REVIEW(partyId, partyName));
   };
 
   if (isLoading) return <FoodPartyListSkeleton foodPartyCount={2} />;
@@ -23,6 +23,9 @@ const MyFoodPartyList = () => {
 
   return (
     <>
+      <Head>
+        <title>내가 참여한 밥모임 목록</title>
+      </Head>
       {isSuccess ? (
         <>
           <Head>

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -63,6 +63,9 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
 
   return (
     <>
+      <Head>
+        <title>{name} 음식점의 밥모임 목록</title>
+      </Head>
       {isSuccess ? (
         <>
           <Head>

--- a/src/pages/food-party/review/[partyId].tsx
+++ b/src/pages/food-party/review/[partyId].tsx
@@ -4,9 +4,17 @@ import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import ReviewBottomDrawer from 'components/FoodParty/Review/ReviewBottomDrawer';
 import { useGetFoodPartyReviewees } from 'hooks/query/useFoodParty';
 import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-const FoodPartyReviewPage = ({ partyId }: { partyId: string }) => {
+
+const FoodPartyReviewPage = ({
+  partyId,
+  partyName,
+}: {
+  partyId: string;
+  partyName: string;
+}) => {
   const router = useRouter();
   const [selectedUserName, setSelectedUserName] = useState('');
   const [selectedUserRole, setSelectedUserRole] = useState('');
@@ -36,89 +44,94 @@ const FoodPartyReviewPage = ({ partyId }: { partyId: string }) => {
   };
 
   return (
-    <Flex bgColor='subBackground' h='100%' justify='center' align='center'>
-      <Flex
-        direction='column'
-        position='relative'
-        w='90%'
-        h='95%'
-        bgColor='white'
-        borderRadius={8}
-        p='2rem 1.2rem'>
-        <Heading fontSize='2xl'>리뷰를 작성해주세요</Heading>
-        <VStack pt='1rem'>
-          {isSuccess &&
-            members.map(
-              ({ userId, nickname, crewMemberRole, profileImgUrl, isReviewed }) => (
-                <Flex
-                  key={userId}
-                  w='100%'
-                  h='4rem'
-                  borderRadius={8}
-                  border='1px solid #e2e5e6'
-                  p='0.25rem 1rem'
-                  align='center'>
-                  <Flex flex='1' h='100%' m='0' align='center' gap='1rem'>
-                    <Avatar src={profileImgUrl} width='2rem' height='2rem' />
-                    <Flex direction='column' flex='1'>
-                      <Text fontSize='lg' fontWeight={800} noOfLines={1}>
-                        {nickname}
-                      </Text>
-                      <Text
-                        textAlign='left'
-                        fontSize='0.6rem'
-                        fontWeight={500}
-                        color='gray.400'>
-                        {crewMemberRole}
-                      </Text>
+    <>
+      <Head>
+        <title>{partyName} - 밥모임 리뷰하기</title>
+      </Head>
+      <Flex bgColor='subBackground' h='100%' justify='center' align='center'>
+        <Flex
+          direction='column'
+          position='relative'
+          w='90%'
+          h='95%'
+          bgColor='white'
+          borderRadius={8}
+          p='2rem 1.2rem'>
+          <Heading fontSize='2xl'>리뷰를 작성해주세요</Heading>
+          <VStack pt='1rem'>
+            {isSuccess &&
+              members.map(
+                ({ userId, nickname, crewMemberRole, profileImgUrl, isReviewed }) => (
+                  <Flex
+                    key={userId}
+                    w='100%'
+                    h='4rem'
+                    borderRadius={8}
+                    border='1px solid #e2e5e6'
+                    p='0.25rem 1rem'
+                    align='center'>
+                    <Flex flex='1' h='100%' m='0' align='center' gap='1rem'>
+                      <Avatar src={profileImgUrl} width='2rem' height='2rem' />
+                      <Flex direction='column' flex='1'>
+                        <Text fontSize='lg' fontWeight={800} noOfLines={1}>
+                          {nickname}
+                        </Text>
+                        <Text
+                          textAlign='left'
+                          fontSize='0.6rem'
+                          fontWeight={500}
+                          color='gray.400'>
+                          {crewMemberRole}
+                        </Text>
+                      </Flex>
                     </Flex>
+                    <Button
+                      width='auto'
+                      height='2rem'
+                      onClick={() =>
+                        handleClickReviewButton(nickname, crewMemberRole, userId)
+                      }
+                      disabled={isReviewed ? true : false}
+                      style={{
+                        fontSize: '0.75rem',
+                        fontWeight: '600',
+                        borderRadius: '0.5rem',
+                        padding: '0.25rem 0.5rem',
+                        color: isReviewed ? 'green.800' : 'orange.800',
+                        backgroundColor: isReviewed ? 'green.100' : 'orange.100',
+                      }}>
+                      {isReviewed ? '리뷰완료' : '리뷰하러 가기'}
+                    </Button>
+                    <ReviewBottomDrawer
+                      isOpen={isOpen}
+                      onClose={onClose}
+                      selectedUserRole={selectedUserRole}
+                      selectedUserName={selectedUserName}
+                      selectedUserId={selectedUserId}
+                      partyId={partyId}
+                    />
                   </Flex>
-                  <Button
-                    width='auto'
-                    height='2rem'
-                    onClick={() =>
-                      handleClickReviewButton(nickname, crewMemberRole, userId)
-                    }
-                    disabled={isReviewed ? true : false}
-                    style={{
-                      fontSize: '0.75rem',
-                      fontWeight: '600',
-                      borderRadius: '0.5rem',
-                      padding: '0.25rem 0.5rem',
-                      color: isReviewed ? 'green.800' : 'orange.800',
-                      backgroundColor: isReviewed ? 'green.100' : 'orange.100',
-                    }}>
-                    {isReviewed ? '리뷰완료' : '리뷰하러 가기'}
-                  </Button>
-                  <ReviewBottomDrawer
-                    isOpen={isOpen}
-                    onClose={onClose}
-                    selectedUserRole={selectedUserRole}
-                    selectedUserName={selectedUserName}
-                    selectedUserId={selectedUserId}
-                    partyId={partyId}
-                  />
-                </Flex>
-              )
-            )}
-        </VStack>
-        <Button
-          onClick={handleClickGoBackToList}
-          width='80%'
-          style={{
-            position: 'absolute',
-            left: '2.4rem',
-            right: 0,
-            bottom: '2rem',
-            backgroundColor: 'white',
-            border: '1px solid',
-            borderColor: 'primary',
-            color: 'primary',
-          }}>
-          &lt; 밥모임 목록으로 돌아가기
-        </Button>
+                )
+              )}
+          </VStack>
+          <Button
+            onClick={handleClickGoBackToList}
+            width='80%'
+            style={{
+              position: 'absolute',
+              left: '2.4rem',
+              right: 0,
+              bottom: '2rem',
+              backgroundColor: 'white',
+              border: '1px solid',
+              borderColor: 'primary',
+              color: 'primary',
+            }}>
+            &lt; 밥모임 목록으로 돌아가기
+          </Button>
+        </Flex>
       </Flex>
-    </Flex>
+    </>
   );
 };
 
@@ -126,11 +139,12 @@ export default FoodPartyReviewPage;
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { partyId } = context.query;
+  const { partyId, partyName } = context.query;
 
   return {
     props: {
       partyId,
+      partyName,
     },
   };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ const Home = () => {
   return (
     <>
       <Head>
-        <title>Home</title>
+        <title>끼니</title>
       </Head>
       <KakaoMap />;
     </>

--- a/src/pages/oauth.tsx
+++ b/src/pages/oauth.tsx
@@ -26,6 +26,9 @@ const OAuthLogin = () => {
 
   return (
     <>
+      <Head>
+        <title>로그인</title>
+      </Head>
       {router.query.error ? (
         <GoHomeWhenErrorInvoked />
       ) : (

--- a/src/pages/user/[userId].tsx
+++ b/src/pages/user/[userId].tsx
@@ -41,11 +41,11 @@ const UserPage = ({ userId }: { userId: string }) => {
     window.location.replace(ROUTING_PATHS.HOME);
   };
   return (
-    isSuccess && (
-      <>
-        <Head>
-          <title>Profile</title>
-        </Head>
+    <>
+      <Head>
+        <title>나의 프로필</title>
+      </Head>
+      {isSuccess ? (
         <motion.div
           initial={{ x: 300 }}
           animate={{ x: 0 }}
@@ -130,8 +130,10 @@ const UserPage = ({ userId }: { userId: string }) => {
             )}
           </Flex>
         </motion.div>
-      </>
-    )
+      ) : (
+        <GoHomeWhenErrorInvoked />
+      )}
+    </>
   );
 };
 

--- a/src/pages/user/edit.tsx
+++ b/src/pages/user/edit.tsx
@@ -8,6 +8,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import Button from 'components/common/Button';
+import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import UserIconForm from 'components/User/Edit/UserIconForm';
 import { useGetUser, useUpdateMyProfile } from 'hooks/query/useUser';
 import Head from 'next/head';
@@ -49,11 +50,11 @@ const MyProfileEditPage = () => {
   };
 
   return (
-    isSuccess && (
-      <>
-        <Head>
-          <title>Edit Profile</title>
-        </Head>
+    <>
+      <Head>
+        <title>프로필 수정</title>
+      </Head>
+      {isSuccess ? (
         <Flex justify='center' align='center' h='100%' bgColor='subBackground'>
           <Flex
             direction='column'
@@ -128,8 +129,10 @@ const MyProfileEditPage = () => {
             </form>
           </Flex>
         </Flex>
-      </>
-    )
+      ) : (
+        <GoHomeWhenErrorInvoked />
+      )}
+    </>
   );
 };
 

--- a/src/utils/constants/routingPaths.ts
+++ b/src/utils/constants/routingPaths.ts
@@ -11,7 +11,8 @@ const ROUTING_PATHS = {
       INFORMATION: (partyId: string | number) => `/food-party/detail/${partyId}`,
       CHAT: (roomId: string | number) => `/food-party/detail/chat/${roomId}`,
     },
-    REVIEW: (partyId: string | number) => `/food-party/review/${partyId}`,
+    REVIEW: (partyId: string | number, partyName: string) =>
+      `/food-party/review/${partyId}?partyName=${partyName}`,
   },
   USER: {
     PROFILE: (userId: string | number) => `/user/${userId}`,


### PR DESCRIPTION
## 💡 Linked Issues

- close #193 

## 📖 구현 내용

- Google Analytics 페이지 추적을 위해 각 페이지마다 title 태그 추가
  - Google Analytics에서 구현 이미지처럼 페이지 추적이 가능해집니다.

## 🖼 참고
- 밑의 사진은 임시로 실험해본 것입니다. 이 PR이 머지되면 영어가 아니라 한글로 기록될 예정입니다.
![image](https://user-images.githubusercontent.com/93233930/230395925-176f8e41-ce24-47bc-adf3-cfb0fc598bb7.png)

## ✅ PR 포인트 & 궁금한 점
