### PR TITLE
SSR 제거

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -7,7 +7,7 @@ const Custom404 = () => {
   return (
     <>
       <Head>
-        <title>Not Found</title>
+        <title>404 Not Found 페이지</title>
       </Head>
       <Box width='100%' height='100%' backgroundColor='subBackground'>
         <GoHomeWhenErrorInvoked errorText='존재하지 않는 페이지에요..!'>

--- a/src/pages/food-party/create.tsx
+++ b/src/pages/food-party/create.tsx
@@ -5,7 +5,7 @@ const Create = () => {
   return (
     <>
       <Head>
-        <title>Create Food Party</title>
+        <title>밥모임 생성</title>
       </Head>
       <FoodPartyCreateForm />;
     </>

--- a/src/pages/food-party/detail/[partyId].tsx
+++ b/src/pages/food-party/detail/[partyId].tsx
@@ -16,7 +16,6 @@ import {
   useUpdateFoodPartyStatus,
 } from 'hooks/query/useFoodParty';
 import { useGetUser } from 'hooks/query/useUser';
-import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
@@ -32,8 +31,9 @@ import { validateAbleToChat, validateAbleToKickOut } from 'utils/validations/foo
 
 // To Do: 404 처리 by 승준
 // 조회가 안되면 에러 코드({"code":"CR001","message":"존재하지 않는 모임입니다."}) 맵핑하여 404 처리
-const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
+const FoodPartyDetail = () => {
   const router = useRouter();
+  const partyId = router.query.partyId as string;
   const { data: userInformation } = useGetUser();
   // To Do: 실시간 업데이트를 위한 refetch 필요 by 승준
   const {
@@ -227,14 +227,3 @@ const FoodPartyDetail = ({ partyId }: { partyId: string }) => {
 };
 
 export default FoodPartyDetail;
-
-// eslint-disable-next-line @typescript-eslint/require-await
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { partyId } = context.query;
-
-  return {
-    props: {
-      partyId,
-    },
-  };
-};

--- a/src/pages/food-party/detail/chat/[roomId].tsx
+++ b/src/pages/food-party/detail/chat/[roomId].tsx
@@ -10,15 +10,17 @@ import {
   useGetFoodPartyMessageList,
 } from 'hooks/query/useFoodParty';
 import { useGetUser } from 'hooks/query/useUser';
-import { GetServerSideProps } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import SockJS from 'sockjs-client';
 import { Message, ReceivedMessage } from 'types/foodParty';
 import { sendMessage } from 'utils/helpers/chat';
 import { getNumberArrayCreatedAt } from 'utils/helpers/foodParty';
 
-const FoodPartyDetailChat = ({ roomId }: { roomId: string }) => {
+const FoodPartyDetailChat = () => {
+  const router = useRouter();
+  const roomId = router.query.roomId as string;
   const client = useRef<CompatClient>();
   const messageListRef = useRef<HTMLDivElement>(null);
   const messageInputRef = useRef<HTMLInputElement>(null);
@@ -175,26 +177,21 @@ const FoodPartyDetailChat = ({ roomId }: { roomId: string }) => {
       isSuccessGettingExistingMessageList &&
       isSuccessGettingUserInformation &&
       isSuccessGettingFoodPartyDetail ? (
-        <>
-          <Head>
-            <title>Chat of {foodPartyDetail.id}</title>
-          </Head>
-          <Flex
-            position='relative'
-            flexDirection='column'
-            height='100%'
-            backgroundColor='#f2f2f2'>
-            <MessageList
-              status={foodPartyDetail.crewStatus}
-              ref={messageListRef}
-              messageList={messageList}
-              currentUserId={userInformation.id}
-            />
-            {foodPartyDetail.crewStatus !== '식사 완료' && (
-              <MessageInput ref={messageInputRef} onSendMessage={handleSendMessage} />
-            )}
-          </Flex>
-        </>
+        <Flex
+          position='relative'
+          flexDirection='column'
+          height='100%'
+          backgroundColor='#f2f2f2'>
+          <MessageList
+            status={foodPartyDetail.crewStatus}
+            ref={messageListRef}
+            messageList={messageList}
+            currentUserId={userInformation.id}
+          />
+          {foodPartyDetail.crewStatus !== '식사 완료' && (
+            <MessageInput ref={messageInputRef} onSendMessage={handleSendMessage} />
+          )}
+        </Flex>
       ) : (
         <GoHomeWhenErrorInvoked
           errorText={isErrorConnectingSocket ? '채팅 연결에 실패했습니다.' : ''}
@@ -205,14 +202,3 @@ const FoodPartyDetailChat = ({ roomId }: { roomId: string }) => {
 };
 
 export default FoodPartyDetailChat;
-
-// eslint-disable-next-line @typescript-eslint/require-await
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { roomId } = context.query;
-
-  return {
-    props: {
-      roomId,
-    },
-  };
-};

--- a/src/pages/food-party/list/my.tsx
+++ b/src/pages/food-party/list/my.tsx
@@ -27,20 +27,15 @@ const MyFoodPartyList = () => {
         <title>내가 참여한 밥모임 목록</title>
       </Head>
       {isSuccess ? (
-        <>
-          <Head>
-            <title>My Food Party List</title>
-          </Head>
-          <Flex flexDirection='column' padding='1rem'>
-            <Heading paddingBottom='1rem'>나의 밥모임 목록</Heading>
-            <FoodPartyList
-              isMyFoodParty
-              foodPartyList={myFoodPartyList}
-              onClickViewButton={handleClickViewFoodPartyButton}
-              onClickReviewButton={handleClickReviewFoodPartyButton}
-            />
-          </Flex>
-        </>
+        <Flex flexDirection='column' padding='1rem'>
+          <Heading paddingBottom='1rem'>나의 밥모임 목록</Heading>
+          <FoodPartyList
+            isMyFoodParty
+            foodPartyList={myFoodPartyList}
+            onClickViewButton={handleClickViewFoodPartyButton}
+            onClickReviewButton={handleClickReviewFoodPartyButton}
+          />
+        </Flex>
       ) : (
         <GoHomeWhenErrorInvoked />
       )}

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -13,13 +13,14 @@ import { getPhotoUrlsArray } from 'utils/helpers/foodParty';
 
 const SearchedFoodPartyList = () => {
   const router = useRouter();
-  const { placeId, restaurantName } = router.query;
+  const placeId = router.query.placeId as string;
+  const restaurantName = router.query.restaurantName as string;
   const {
     data: foodPartyList,
     isLoading,
     error,
     isSuccess,
-  } = useGetSearchedFoodPartyList(placeId as string);
+  } = useGetSearchedFoodPartyList(placeId);
   const { randomRestaurant } = useRandomRestaurantContext();
   const setSelectedRestaurant = useSetRecoilState(selectedRestaurantState);
 

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -4,7 +4,6 @@ import FoodPartyList from 'components/FoodParty/FoodPartyList';
 import FoodPartyListSkeleton from 'components/FoodParty/FoodPartyListSkeleton';
 import useRandomRestaurantContext from 'contexts/kakaoMap/randomRestaurant';
 import { useGetSearchedFoodPartyList } from 'hooks/query/useFoodParty';
-import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useSetRecoilState } from 'recoil';
@@ -12,23 +11,18 @@ import { selectedRestaurantState } from 'stores/restaurant';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 import { getPhotoUrlsArray } from 'utils/helpers/foodParty';
 
-type SearchedFoodPartyListQuery = {
-  placeId: string;
-  name: string;
-};
-
-type SearchedFoodPartyListProps = SearchedFoodPartyListQuery;
-
-const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) => {
+const SearchedFoodPartyList = () => {
+  const router = useRouter();
+  const { placeId, restaurantName } = router.query;
   const {
     data: foodPartyList,
     isLoading,
     error,
     isSuccess,
-  } = useGetSearchedFoodPartyList(placeId);
+  } = useGetSearchedFoodPartyList(placeId as string);
   const { randomRestaurant } = useRandomRestaurantContext();
   const setSelectedRestaurant = useSetRecoilState(selectedRestaurantState);
-  const router = useRouter();
+
   const handleClickFoodPartyItem = (partyId: number) => {
     router.push(ROUTING_PATHS.FOOD_PARTY.DETAIL.INFORMATION(partyId));
   };
@@ -64,15 +58,12 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
   return (
     <>
       <Head>
-        <title>{name} 음식점의 밥모임 목록</title>
+        <title>{restaurantName} 음식점의 밥모임 목록</title>
       </Head>
       {isSuccess ? (
         <>
-          <Head>
-            <title>Food Party List of {name}</title>
-          </Head>
           <Flex flexDirection='column' padding='1rem'>
-            <Heading paddingBottom='1rem'>{name}의 밥모임</Heading>
+            <Heading paddingBottom='1rem'>{restaurantName}의 밥모임</Heading>
             <FoodPartyList
               isMyFoodParty={false}
               foodPartyList={foodPartyList}
@@ -89,15 +80,3 @@ const SearchedFoodPartyList = ({ placeId, name }: SearchedFoodPartyListProps) =>
 };
 
 export default SearchedFoodPartyList;
-
-// eslint-disable-next-line @typescript-eslint/require-await
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { placeId, name } = context.query;
-
-  return {
-    props: {
-      placeId,
-      name,
-    },
-  };
-};

--- a/src/pages/food-party/list/restaurant/[placeId].tsx
+++ b/src/pages/food-party/list/restaurant/[placeId].tsx
@@ -13,8 +13,10 @@ import { getPhotoUrlsArray } from 'utils/helpers/foodParty';
 
 const SearchedFoodPartyList = () => {
   const router = useRouter();
-  const placeId = router.query.placeId as string;
-  const restaurantName = router.query.restaurantName as string;
+  const { placeId, restaurantName } = router.query as {
+    placeId: string;
+    restaurantName: string;
+  };
   const {
     data: foodPartyList,
     isLoading,

--- a/src/pages/food-party/review/[partyId].tsx
+++ b/src/pages/food-party/review/[partyId].tsx
@@ -3,19 +3,13 @@ import Button from 'components/common/Button';
 import GoHomeWhenErrorInvoked from 'components/common/GoHomeWhenErrorInvoked';
 import ReviewBottomDrawer from 'components/FoodParty/Review/ReviewBottomDrawer';
 import { useGetFoodPartyReviewees } from 'hooks/query/useFoodParty';
-import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
-const FoodPartyReviewPage = ({
-  partyId,
-  partyName,
-}: {
-  partyId: string;
-  partyName: string;
-}) => {
+const FoodPartyReviewPage = () => {
   const router = useRouter();
+  const { partyId, partyName } = router.query;
   const [selectedUserName, setSelectedUserName] = useState('');
   const [selectedUserRole, setSelectedUserRole] = useState('');
   const [selectedUserId, setsSelectedUserId] = useState(0);
@@ -25,7 +19,7 @@ const FoodPartyReviewPage = ({
     isLoading,
     error,
     isSuccess,
-  } = useGetFoodPartyReviewees(partyId);
+  } = useGetFoodPartyReviewees(partyId as string);
 
   if (isLoading) return <div></div>;
   if (error) return <GoHomeWhenErrorInvoked />;
@@ -108,7 +102,7 @@ const FoodPartyReviewPage = ({
                       selectedUserRole={selectedUserRole}
                       selectedUserName={selectedUserName}
                       selectedUserId={selectedUserId}
-                      partyId={partyId}
+                      partyId={partyId as string}
                     />
                   </Flex>
                 )
@@ -136,15 +130,3 @@ const FoodPartyReviewPage = ({
 };
 
 export default FoodPartyReviewPage;
-
-// eslint-disable-next-line @typescript-eslint/require-await
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { partyId, partyName } = context.query;
-
-  return {
-    props: {
-      partyId,
-      partyName,
-    },
-  };
-};

--- a/src/pages/food-party/review/[partyId].tsx
+++ b/src/pages/food-party/review/[partyId].tsx
@@ -9,7 +9,8 @@ import { useState } from 'react';
 
 const FoodPartyReviewPage = () => {
   const router = useRouter();
-  const { partyId, partyName } = router.query;
+  const partyId = router.query.partyId as string;
+  const partyName = router.query.partyName as string;
   const [selectedUserName, setSelectedUserName] = useState('');
   const [selectedUserRole, setSelectedUserRole] = useState('');
   const [selectedUserId, setsSelectedUserId] = useState(0);
@@ -19,7 +20,7 @@ const FoodPartyReviewPage = () => {
     isLoading,
     error,
     isSuccess,
-  } = useGetFoodPartyReviewees(partyId as string);
+  } = useGetFoodPartyReviewees(partyId);
 
   if (isLoading) return <div></div>;
   if (error) return <GoHomeWhenErrorInvoked />;
@@ -102,7 +103,7 @@ const FoodPartyReviewPage = () => {
                       selectedUserRole={selectedUserRole}
                       selectedUserName={selectedUserName}
                       selectedUserId={selectedUserId}
-                      partyId={partyId as string}
+                      partyId={partyId}
                     />
                   </Flex>
                 )

--- a/src/pages/food-party/review/[partyId].tsx
+++ b/src/pages/food-party/review/[partyId].tsx
@@ -9,8 +9,10 @@ import { useState } from 'react';
 
 const FoodPartyReviewPage = () => {
   const router = useRouter();
-  const partyId = router.query.partyId as string;
-  const partyName = router.query.partyName as string;
+  const { partyId, partyName } = router.query as {
+    partyId: string;
+    partyName: string;
+  };
   const [selectedUserName, setSelectedUserName] = useState('');
   const [selectedUserRole, setSelectedUserRole] = useState('');
   const [selectedUserId, setsSelectedUserId] = useState(0);

--- a/src/pages/user/[userId].tsx
+++ b/src/pages/user/[userId].tsx
@@ -16,15 +16,15 @@ import UserProfileCount from 'components/User/UserProfileCount';
 import UserProfileItem from 'components/User/UserProfileItem';
 import { motion } from 'framer-motion';
 import { useGetSpecificUser, useGetUser } from 'hooks/query/useUser';
-import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { logout } from 'services/auth';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 import { isMyProfile } from 'utils/validations/user';
 
-const UserPage = ({ userId }: { userId: string }) => {
+const UserPage = () => {
   const router = useRouter();
+  const userId = router.query.userId as string;
 
   const { data: MyUserData } = useGetUser();
   const { data, isLoading, error, isSuccess } = useGetSpecificUser(userId);
@@ -138,14 +138,3 @@ const UserPage = ({ userId }: { userId: string }) => {
 };
 
 export default UserPage;
-
-// eslint-disable-next-line @typescript-eslint/require-await
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { userId } = context.query;
-
-  return {
-    props: {
-      userId,
-    },
-  };
-};

--- a/src/utils/constants/routingPaths.ts
+++ b/src/utils/constants/routingPaths.ts
@@ -5,7 +5,7 @@ const ROUTING_PATHS = {
     LIST: {
       MY: '/food-party/list/my',
       RESTAURANT: (placeId: string | number, placeName: string) =>
-        `/food-party/list/restaurant/${placeId}?name=${placeName}`,
+        `/food-party/list/restaurant/${placeId}?restaurantName=${placeName}`,
     },
     DETAIL: {
       INFORMATION: (partyId: string | number) => `/food-party/detail/${partyId}`,


### PR DESCRIPTION
## 💡 Linked Issues

- close #200

## 📖 구현 내용

- 현재는 query string이 처음에 undefined가 아니게 만들기 위해 getServerSideProps를 사용하고 있습니다. 하지만 실험해보니 undefined가 찍히진 않고, 처음부터 제대로 값을 찍어냅니다. 따라서 현재 느린 속도의 원인으로 보이는 getServerSideProps를 제거합니다.

## ✅ 참고

- 개발 서버로 돌릴 때 문제는 딱히 생기지 않았습니다. 시범적으로 내 프로필 페이지만 잠시 배포 서버에 실험해봤는데 이전처럼 느리게 나타나지 않고 빠르게 나타납니다.