### PR TITLE
모바일 화면에서 네비게이션 바가 보이지 않는 현상 해결

### DIFF
--- a/src/hooks/useAdjustHeightForMobileView.ts
+++ b/src/hooks/useAdjustHeightForMobileView.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import debounce from 'utils/helpers/debounce';
+
+const DEFAULT_DEBOUNCE_DELAY_TIME = 150;
+
+const useAdjustHeightForMobileView = () => {
+  useEffect(() => {
+    // 처음에 한 번 높이를 맞춰줌.
+    adjustHeight();
+
+    const adjustHeightFunctionDebounced = debounce(
+      adjustHeight,
+      DEFAULT_DEBOUNCE_DELAY_TIME
+    );
+
+    // 브라우저 화면의 크기가 변할 경우 adjustHeight 실행.
+    window.addEventListener('resize', adjustHeightFunctionDebounced);
+    return () => {
+      window.removeEventListener('resize', adjustHeightFunctionDebounced);
+    };
+  }, []);
+};
+
+export default useAdjustHeightForMobileView;
+
+const adjustHeight = () => {
+  // 모바일이면 뷰포트에서 주소창을 제외한 높이, 웹이면 그냥 뷰포트 높이
+  const heightExcludingAddressBar = window.innerHeight;
+  document.documentElement.style.setProperty(
+    '--height-excluding-address-bar',
+    `${heightExcludingAddressBar}px`
+  );
+};

--- a/src/hooks/useAdjustHeightForMobileView.ts
+++ b/src/hooks/useAdjustHeightForMobileView.ts
@@ -1,17 +1,10 @@
 import { useEffect } from 'react';
 import debounce from 'utils/helpers/debounce';
 
-const DEFAULT_DEBOUNCE_DELAY_TIME = 150;
-
 const useAdjustHeightForMobileView = () => {
   useEffect(() => {
     // 처음에 한 번 높이를 맞춰줌.
     adjustHeight();
-
-    const adjustHeightFunctionDebounced = debounce(
-      adjustHeight,
-      DEFAULT_DEBOUNCE_DELAY_TIME
-    );
 
     // 브라우저 화면의 크기가 변할 경우 adjustHeight 실행.
     window.addEventListener('resize', adjustHeightFunctionDebounced);
@@ -31,3 +24,7 @@ const adjustHeight = () => {
     `${heightExcludingAddressBar}px`
   );
 };
+
+const DEFAULT_DEBOUNCE_DELAY_TIME = 150;
+
+const adjustHeightFunctionDebounced = debounce(adjustHeight, DEFAULT_DEBOUNCE_DELAY_TIME);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import Layout from 'components/common/Layout';
 import { KakaoMapProvider } from 'contexts/kakaoMap';
 import { RandomRestaurantProvider } from 'contexts/kakaoMap/randomRestaurant';
+import useAdjustHeightForMobileView from 'hooks/useAdjustHeightForMobileView';
 import useRouteChangeTracker from 'hooks/useRouteChangeTracker';
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
@@ -17,8 +18,10 @@ const App = ({
   Component,
   pageProps,
 }: AppProps<{ dehydratedState: DehydratedState }>) => {
-  useRouteChangeTracker();
   const [queryClient] = useState(() => new QueryClient());
+
+  useRouteChangeTracker();
+  useAdjustHeightForMobileView();
 
   return (
     <RecoilRoot>

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,6 +1,10 @@
 import { css } from '@emotion/react';
 
 const globalStyle = css`
+  :root {
+    --height-excluding-address-bar: 100vh;
+  }
+
   * {
     box-sizing: border-box;
   }
@@ -13,7 +17,7 @@ const globalStyle = css`
   #app {
     max-width: 560px;
     width: 100%;
-    height: 100vh;
+    height: var(--height-excluding-address-bar);
   }
 
   // 스크롤바 없애기

--- a/src/utils/helpers/debounce.ts
+++ b/src/utils/helpers/debounce.ts
@@ -1,0 +1,11 @@
+const debounce = (callback: () => void, delayTime: number) => {
+  let timerId: NodeJS.Timeout | null = null;
+
+  return () => {
+    if (timerId) clearTimeout(timerId);
+
+    timerId = setTimeout(callback, delayTime);
+  };
+};
+
+export default debounce;


### PR DESCRIPTION
## 💡 Linked Issues

- close #204

## 📖 구현 내용
### 원인
- #app의 height가 100vh이기 때문에 문제 발생.
  - 모바일에서 주소창이 내려오면 그만큼 밀려나게 됨.

```css
#app {
  max-width: 560px;
  width: 100%;
  height: 100vh;
}
```

<br />

### 해결
모바일 환경에서 주소창을 제외한 높이를 #app의 height로 설정해야 함.
- window.innerHeight를 통해 모바일 환경에서 주소창을 제외한 높이를 정확하게 구할 수 있음.
- 추가로 브라우저 화면 크기가 달라지면 #app의 height도 window.innerHeight가 되도록 변경.
  - 이렇게 하지 않으면 브라우저 화면 크기가 달라져도 height가 그대로임.
- debounce를 통해 #app의 height를 변경하는 adjustHeight 함수가 무분별하게 실행되는 것을 방지.
  - 인간이 답답함을 느끼지 않을 수 있는 속도를 고려하여 150ms로 debounce time 설정.(이전에 stackoverflow에서 대략 150~250 정도가 좋다는 글을 봤었는데 제대로 찾기가 힘드네요!)

<br />

### 결론
window.innerHeight를 이용해 모바일에서는 주소창을 제외한 높이를 전체 높이로 설정하도록 구현.

## 🖼 구현 이미지
![kkini-mobile-screen](https://user-images.githubusercontent.com/93233930/231992656-765187c0-e0c6-408d-9c63-36fe265f42b9.jpeg)

## 참고
모바일 100vh라는 단어로 검색하면 관련된 글들을 보실 수 있습니다.

## 질문
혹시나 해서 주석 달아놨는데 이해가 되실까요? 이해하고 나서 필요 없는 주석이라는 판단이 들면 지우고 머지하겠습니다.
