### PR TITLE
이미지에 에러나거나 로드 안될 시 기본 이미지 렌더링

### DIFF
--- a/src/components/Search/SearchRestaurantItem.tsx
+++ b/src/components/Search/SearchRestaurantItem.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { foodPartyCreateDrawerOpenState } from 'stores/drawer';
 import { searchRestaurantListState, selectedRestaurantState } from 'stores/restaurant';
+import { DEFAULT_IMAGE } from 'utils/constants/foodParty';
 import ROUTING_PATHS from 'utils/constants/routingPaths';
 import { getCategoryArray } from 'utils/helpers/foodParty';
 
@@ -94,6 +95,8 @@ const SearchRestaurantItem = ({
                 borderRadius={8}
                 objectFit='cover'
                 src={photoUrl}
+                fallbackStrategy={'onError' || 'beforeLoadOrError'}
+                fallbackSrc={DEFAULT_IMAGE}
                 alt='food'
               />
             ))}

--- a/src/hooks/useSearchRestaurant.ts
+++ b/src/hooks/useSearchRestaurant.ts
@@ -3,10 +3,9 @@ import { foodPartyCreateDrawerOpenState } from 'stores/drawer';
 import { kakaoMapOptionsState } from 'stores/kakaoMap';
 import { searchRestaurantListState } from 'stores/restaurant';
 import { AxiosPhotoResponseValue } from 'types/kakaoSearch';
+import { DEFAULT_IMAGE } from 'utils/constants/foodParty';
 import { keywordSearch } from 'utils/helpers/kakaoMap';
 import { getKeywordPhotos } from 'utils/helpers/kakaoSearch';
-
-const DEFAULT_IMAGE = '/images/default-restaurant.svg';
 
 const useSearchRestaurant = () => {
   const kakaoMapOptions = useRecoilValue(kakaoMapOptionsState);

--- a/src/utils/constants/foodParty.ts
+++ b/src/utils/constants/foodParty.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_IMAGE = '/images/default-restaurant.svg';
+
 export const foodPartyCategory = [
   {
     title: '신나는 술자리',


### PR DESCRIPTION
## 📖 구현 내용

- deafult Image 상수 분리
- onError, load 되지 않으면 default image 띄워주기

## 🖼 구현 이미지
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/28768535/235872636-8f172748-e7bd-4b7a-9a6c-9a4bf3a30ee1.png">

## ✅ PR 포인트 & 궁금한 점
- 사당 전주 식당은 http 오류라 배포에서만 테스트가 가능해서 아직 확인이 안되는데 안되면 다시 고쳐보겠습니다!