### PR TITLE
브라우저 환경에서 동작하는 debounce 함수에서 사용되는 timerId 타입을 number로 변경

### DIFF
--- a/src/utils/helpers/debounce.ts
+++ b/src/utils/helpers/debounce.ts
@@ -1,10 +1,11 @@
 const debounce = (callback: () => void, delayTime: number) => {
-  let timerId: NodeJS.Timeout | null = null;
+  let timerId: number;
 
   return () => {
-    if (timerId) clearTimeout(timerId);
+    if (!window) return;
+    if (timerId) window.clearTimeout(timerId);
 
-    timerId = setTimeout(callback, delayTime);
+    timerId = window.setTimeout(callback, delayTime);
   };
 };
 


### PR DESCRIPTION
## 💡 Linked Issues

- close #211

## 📖 구현 내용

- [모바일 화면에서 네비게이션 바가 보이지 않는 현상 해결](https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-FE/pull/205) <- 해당 PR에서 수화님이 제기한 setTimeout 관련 문제점 발견 후 개선
  - debounce가 브라우저 환경에서 동작하면 setTimeout의 반환값은 number가 맞습니다.
  - 하지만 그냥 setTimeout으로 실행하면 노드 환경에서 실행된다고 판단하는지 반환값이 NodeJS.Timeout 타입이 됩니다.
  - debounce가 브라우저 환경에서 동작하는 것임을 타입으로 표현하기 위해 수정

## 🖼 참고
왼쪽은 브라우저 환경에서 실행되는 window.setTimeout의 반환 타입, 오른쪽은 노드 환경에서 실행되는 setTimeout의 반환 타입입니다.
![스크린샷 2023-05-03 오후 9 05 42](https://user-images.githubusercontent.com/93233930/235912813-a0d1b051-50be-48a2-abd1-0bfe297f41cb.png)
