### PR TITLE
채팅 response 리팩토링 

### DIFF
--- a/src/components/FoodParty/FoodPartyDetail/Chat/MessageList.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/Chat/MessageList.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text } from '@chakra-ui/react';
 import { forwardRef } from 'react';
-import { FoodPartyStatus, Message } from 'types/foodParty';
+import { FoodPartyStatus, Member, Message } from 'types/foodParty';
 import { getMessageListCheckedIsFirstMessageOfThatDay } from 'utils/helpers/chat';
 
 import MessageListItem from './MessageListitem';
@@ -9,10 +9,11 @@ type MessageListProps = {
   status: FoodPartyStatus;
   messageList: Message[];
   currentUserId: number;
+  memberList: Member[];
 };
 
 const MessageList = forwardRef<HTMLDivElement, MessageListProps>(
-  ({ status, messageList, currentUserId }, ref) => {
+  ({ status, messageList, currentUserId, memberList }, ref) => {
     const messageListCheckedIsFirstMessageOfThatDay =
       getMessageListCheckedIsFirstMessageOfThatDay(messageList);
 
@@ -29,6 +30,7 @@ const MessageList = forwardRef<HTMLDivElement, MessageListProps>(
             key={message.id}
             message={message}
             currentUserId={currentUserId}
+            memberList={memberList}
           />
         ))}
         {status === '식사 완료' && (

--- a/src/components/FoodParty/FoodPartyDetail/Chat/MessageListitem.tsx
+++ b/src/components/FoodParty/FoodPartyDetail/Chat/MessageListitem.tsx
@@ -1,17 +1,20 @@
 import { Avatar, Box, Flex, Text } from '@chakra-ui/react';
-import { Message } from 'types/foodParty';
-import { getIsCurrentUser, templateTime } from 'utils/helpers/chat';
+import { Member, Message } from 'types/foodParty';
+import { getIsCurrentUser, getSpecificUser, templateTime } from 'utils/helpers/chat';
 import { templatePromiseDate } from 'utils/helpers/foodParty';
 
 const MessageListItem = ({
   message,
   currentUserId,
+  memberList,
 }: {
   message: Message;
   currentUserId: number;
+  memberList: Member[];
 }) => {
   const isCurrentUser = getIsCurrentUser(message.userId, currentUserId);
   const [year, month, day, hour, minute] = message.createdAt;
+  const messageSender = getSpecificUser(memberList, message.userId);
 
   return (
     <>
@@ -40,8 +43,12 @@ const MessageListItem = ({
         <Flex flexDirection='column' maxWidth='80%'>
           {!isCurrentUser && (
             <Flex alignItems='center' gap='0.5rem'>
-              <Avatar src={message.profileImgUrl} size='xs' marginBottom='-0.5rem' />
-              <Text fontSize='12px'>{message.username}</Text>
+              <Avatar
+                src={messageSender.profileImgUrl}
+                size='xs'
+                marginBottom='-0.5rem'
+              />
+              <Text fontSize='12px'>{messageSender.nickname}</Text>
             </Flex>
           )}
 

--- a/src/pages/food-party/detail/chat/[roomId].tsx
+++ b/src/pages/food-party/detail/chat/[roomId].tsx
@@ -187,6 +187,7 @@ const FoodPartyDetailChat = () => {
             ref={messageListRef}
             messageList={messageList}
             currentUserId={userInformation.id}
+            memberList={foodPartyDetail.members}
           />
           {foodPartyDetail.crewStatus !== '식사 완료' && (
             <MessageInput ref={messageInputRef} onSendMessage={handleSendMessage} />

--- a/src/types/foodParty.ts
+++ b/src/types/foodParty.ts
@@ -30,8 +30,6 @@ export type Member = {
 export type Message = {
   id: number;
   userId: number;
-  username: string;
-  profileImgUrl: string;
   type: MessageType;
   createdAt: number[];
   content: string;
@@ -41,8 +39,6 @@ export type Message = {
 export type ReceivedMessage = {
   id: number;
   userId: number;
-  username: string;
-  profileImgUrl: string;
   type: MessageType;
   createdAt: string;
   content: string;

--- a/src/utils/helpers/chat.ts
+++ b/src/utils/helpers/chat.ts
@@ -1,5 +1,5 @@
 import { CompatClient } from '@stomp/stompjs';
-import { Message } from 'types/foodParty';
+import { Member, Message } from 'types/foodParty';
 
 export const sendMessage = ({
   client,
@@ -61,4 +61,8 @@ export const templateTime = (hour: number, minute: number) => {
     return `오후 ${String(hour - 12).padStart(2, '0')}:${minuteStartWithZero}`;
 
   return `오전 ${String(hour).padStart(2, '0')}:${minuteStartWithZero}`;
+};
+
+export const getSpecificUser = (memberList: Member[], userId: number) => {
+  return memberList.filter((member) => member.userId === userId)[0];
 };

--- a/src/utils/helpers/chat.ts
+++ b/src/utils/helpers/chat.ts
@@ -64,5 +64,12 @@ export const templateTime = (hour: number, minute: number) => {
 };
 
 export const getSpecificUser = (memberList: Member[], userId: number) => {
-  return memberList.filter((member) => member.userId === userId)[0];
+  const userData = memberList.filter((member) => member.userId === userId);
+  if (!userData[0]) {
+    return {
+      nickname: '퇴장한 사용자',
+      profileImgUrl: '', // chakra avatar에서 사용하기때문에 url 없으면 기본 이미지가 적용됨
+    };
+  }
+  return userData[0];
 };

--- a/src/utils/helpers/chat.ts
+++ b/src/utils/helpers/chat.ts
@@ -64,12 +64,12 @@ export const templateTime = (hour: number, minute: number) => {
 };
 
 export const getSpecificUser = (memberList: Member[], userId: number) => {
-  const userData = memberList.filter((member) => member.userId === userId);
-  if (!userData[0]) {
+  const foundUser = memberList.find((member) => member.userId === userId);
+  if (!foundUser) {
     return {
       nickname: '퇴장한 사용자',
       profileImgUrl: '', // chakra avatar에서 사용하기때문에 url 없으면 기본 이미지가 적용됨
     };
   }
-  return userData[0];
+  return foundUser;
 };


### PR DESCRIPTION
## 💡 Linked Issues

- close #222 

## 📖 구현 내용

- 채팅 Response에서 imageUrl, username 제거 -> 채팅방멤버에서 meesage.userId로 해당 유저 이미지, 닉네임 재사용함
- 채팅방 나갈 경우, '퇴장한 사용자', 기본 이미지가 보이도록 처리함 

## 🖼 구현 이미지
<img width="729" alt="스크린샷 2023-07-14 오후 7 56 57" src="https://github.com/prgrms-web-devcourse/Team-DarkNight-Kkini-FE/assets/70274947/0e925c2a-0c9a-47f7-9cd6-cf1ff42d7921">

